### PR TITLE
Eliminate node bounce

### DIFF
--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -1,7 +1,6 @@
-import { makeMosfet } from '../functions/makeMosfet'
+import { makeMosfet, makeNode } from '../functions/makeMosfet'
 import { Circuit } from '../types'
-import { ref } from 'vue'
-import { gndNodeId, vddNodeId, gndVoltage, vddVoltage, defaultNodeCapacitance, powerSupplyCapacitance } from '../constants'
+import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 
 const useNmosDiffPair = () => {
     const circuit: Circuit = {
@@ -15,14 +14,14 @@ const useNmosDiffPair = () => {
             voltageSources: {}
         },
         nodes: {
-            [gndNodeId]: ref({voltage: gndVoltage, netCurrent: 0, capacitance: powerSupplyCapacitance, fixed: true}),
-            [vddNodeId]: ref({voltage: vddVoltage, netCurrent: 0, capacitance: powerSupplyCapacitance, fixed: true}),
-            "M1_gate": ref({voltage: 2, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
-            "M1_drain": ref({voltage: 5, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
-            "M2_gate": ref({voltage: 2, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
-            "M2_drain": ref({voltage: 5, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
-            "Mb_gate": ref({voltage: 0.7, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
-            "Vnode": ref({voltage: 1, netCurrent: 0, capacitance: defaultNodeCapacitance, fixed: false}),
+            [gndNodeId]: makeNode(gndVoltage, true),
+            [vddNodeId]: makeNode(vddVoltage, true),
+            "M1_gate": makeNode(2, false),
+            // "M1_drain": makeNode(5, false),
+            "M2_gate": makeNode(2, false),
+            // "M2_drain": makeNode(5, false),
+            "Mb_gate": makeNode(0.7, false),
+            "Vnode": makeNode(1, false),
         },
     }
     console.log(circuit.nodes[gndNodeId])

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -1,7 +1,6 @@
-import { makeMosfet } from '../functions/makeMosfet'
+import { makeMosfet, makeNode } from '../functions/makeMosfet'
 import { Circuit } from '../types'
-import { ref } from 'vue'
-import { gndNodeId } from '../constants'
+import { gndNodeId, gndVoltage } from '../constants'
 
 const useNmosSingle = () => {
     const circuit: Circuit = {
@@ -15,9 +14,9 @@ const useNmosSingle = () => {
             voltageSources: {}
         },
         nodes: {
-            [gndNodeId]: ref({voltage: 0, netCurrent: 0, capacitance: 100, fixed: true}),
-            "M1_drain": ref({voltage: 5, netCurrent: 0, capacitance: 1, fixed: false}),
-            "M1_gate": ref({voltage: 1, netCurrent: 0, capacitance: 1, fixed: false}),
+            [gndNodeId]: makeNode(gndVoltage, true),
+            "M1_drain": makeNode(5, false),
+            "M1_gate": makeNode(1, false),
         },
     }
     circuit.devices.mosfets = {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -10,7 +10,7 @@
       <!-- <div>M2_drain: {{ toSiPrefix(circuit.nodes["M2_drain"].value.voltage, "V") }}</div> -->
       <div>Mb_gate: {{ toSiPrefix(circuit.nodes["Mb_gate"].value.voltage, "V") }}</div>
       <div>Vnode: {{ toSiPrefix(circuit.nodes["Vnode"].value.voltage, "V") }}</div>
-      <div>Vnode: {{ circuit.nodes["Vnode"].value.historicVoltages.toArray().map(x => x.toFixed(7)) }}</div>
+      <!-- <div>Vnode: {{ circuit.nodes["Vnode"].value.historicVoltages.toArray().map(x => x.toFixed(7)) }}</div> -->
     </div>
   <canvas ref="canvas" width="500" height="500" @mousedown="checkDrag"></canvas>
 </template>

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -5,11 +5,12 @@
     v-bind:cornerToCornerGraph="true" /> -->
     <div>
       <div>M1_gate: {{ toSiPrefix(circuit.nodes["M1_gate"].value.voltage, "V") }}</div>
-      <div>M1_drain: {{ toSiPrefix(circuit.nodes["M1_drain"].value.voltage, "V") }}</div>
+      <!-- <div>M1_drain: {{ toSiPrefix(circuit.nodes["M1_drain"].value.voltage, "V") }}</div> -->
       <div>M2_gate: {{ toSiPrefix(circuit.nodes["M2_gate"].value.voltage, "V") }}</div>
-      <div>M2_drain: {{ toSiPrefix(circuit.nodes["M2_drain"].value.voltage, "V") }}</div>
+      <!-- <div>M2_drain: {{ toSiPrefix(circuit.nodes["M2_drain"].value.voltage, "V") }}</div> -->
       <div>Mb_gate: {{ toSiPrefix(circuit.nodes["Mb_gate"].value.voltage, "V") }}</div>
       <div>Vnode: {{ toSiPrefix(circuit.nodes["Vnode"].value.voltage, "V") }}</div>
+      <div>Vnode: {{ circuit.nodes["Vnode"].value.historicVoltages.toArray().map(x => x.toFixed(7)) }}</div>
     </div>
   <canvas ref="canvas" width="500" height="500" @mousedown="checkDrag"></canvas>
 </template>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,5 +8,5 @@ export const gndNodeId: string = "GND"
 export const vddNodeId: string = "VDD"
 export const gndVoltage: number = 0 // Volts
 export const vddVoltage: number = 5 // Volts
-export const defaultNodeCapacitance = 10e-6 // Farads
+export const defaultNodeCapacitance = 1.5e-6 // Farads
 export const powerSupplyCapacitance = 100 // Farads

--- a/src/functions/incrementCircuit.ts
+++ b/src/functions/incrementCircuit.ts
@@ -1,4 +1,5 @@
-import { Circuit } from "../types"
+import { type Ref } from "vue"
+import { Circuit, Node } from "../types"
 import { getMosfetCurrent } from "../functions/makeMosfet"
 import { gndNodeId, gndVoltage, vddNodeId, vddVoltage } from "../constants"
 
@@ -42,6 +43,8 @@ export const incrementCircuit = (circuit: Circuit, deltaT: number = 0.01) => {
             continue
         }
 
+        checkNodeBounceAndAdjustCapacitance(node)
+
         let deltaV = node.value.netCurrent / node.value.capacitance * deltaT
         // place an upper and lower bound on how quickly the voltage is allowed to change, since the net current may vary on several orders of magnitude
         if (deltaV > 0.1) {
@@ -51,5 +54,41 @@ export const incrementCircuit = (circuit: Circuit, deltaT: number = 0.01) => {
             deltaV = -0.1
         }
         node.value.voltage += deltaV
+        // add the new value to the historical voltages queue
+        node.value.historicVoltages.dequeue()
+        node.value.historicVoltages.enqueue(node.value.voltage)
+    }
+}
+
+const checkNodeBounceAndAdjustCapacitance = (node: Ref<Node>) => {
+    let direcitonSwitches = 0
+    let previousVoltage = 0
+    let previousIncreasing = true
+    node.value.historicVoltages.toArray().forEach((voltage, idx) => {
+        const increasing = (voltage - previousVoltage > 0)
+        if ((voltage - previousVoltage == 0)) {
+            // continue -- this keyword doesn't work because it's not an actual for loop, so we use if else
+        } else {
+            // check if we were increasing and then switched directions
+            if (increasing !== previousIncreasing) {
+                direcitonSwitches += 1
+            }
+        }
+        previousIncreasing = increasing
+        previousVoltage = voltage
+        if (idx <= 1) {
+            direcitonSwitches = 0 // ignore the first result before assigning previousIncreasing and previousVoltage
+        }
+    })
+    console.log(direcitonSwitches)
+    if (direcitonSwitches >= 1) {
+        node.value.capacitance += node.value.originalCapacitance * 10 // double the capacitance on the node
+    }
+    if (direcitonSwitches < 1) {
+        node.value.capacitance -= node.value.originalCapacitance * 3 // decrease the capacitance
+    }
+    // never let the capacitance get less than it was originally
+    if (node.value.capacitance < node.value.originalCapacitance) {
+        node.value.capacitance = node.value.originalCapacitance
     }
 }

--- a/src/functions/incrementCircuit.ts
+++ b/src/functions/incrementCircuit.ts
@@ -80,12 +80,12 @@ const checkNodeBounceAndAdjustCapacitance = (node: Ref<Node>) => {
             direcitonSwitches = 0 // ignore the first result before assigning previousIncreasing and previousVoltage
         }
     })
-    console.log(direcitonSwitches)
+    // console.log(direcitonSwitches)
     if (direcitonSwitches >= 1) {
         node.value.capacitance += node.value.originalCapacitance * 10 // double the capacitance on the node
     }
     if (direcitonSwitches < 1) {
-        node.value.capacitance -= node.value.originalCapacitance * 3 // decrease the capacitance
+        node.value.capacitance -= node.value.originalCapacitance * 10 // decrease the capacitance
     }
     // never let the capacitance get less than it was originally
     if (node.value.capacitance < node.value.originalCapacitance) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,9 @@ export type Node = {
   voltage: number, // in Volts
   netCurrent: number, // in Amps
   capacitance: number, // in Farads
+  originalCapacitance: number // in
   fixed: boolean, // GND and VDD nodes are fixed, as are nodes that are being dragged
+  historicVoltages: Queue<number>,
 }
 
 export type Circuit = {
@@ -99,4 +101,36 @@ export type Circuit = {
   nodes: {[nodeId: string]: Ref<Node>}, // a dictionary mapping the names of the nodes in the circuit with their voltages (in V)
   // solveNodeVoltages: (circuit: Circuit) => void, // a function that returns a list of the voltages (in V) at each of the nodes of the circuit
   // checkKirchoffsLaws: () => void, // a function that runs a series of assertions ensuring that KCL and KVL hold within a small tolerance
+}
+
+export class Queue<T> { // from https://www.basedash.com/blog/how-to-implement-a-queue-in-typescript
+  public items: T[] = [];
+
+  enqueue(item: T): void {
+      this.items.push(item);
+  }
+
+  dequeue(): T | undefined {
+      return this.items.shift();
+  }
+
+  peek(): T | undefined {
+      return this.items[0];
+  }
+
+  isEmpty(): boolean {
+      return this.items.length === 0;
+  }
+
+  size(): number {
+      return this.items.length;
+  }
+
+  toArray(): T[] {
+    return this.items
+  }
+
+  fill(item: T, size: number) {
+    this.items = Array(size).fill(item)
+  }
 }


### PR DESCRIPTION
Add a control loop--esque extra step to the differential equation solution to increase the capacitance of a node whenever bouncing occurs. It's moderately successful, although some edge cases still create bouncing.