### PR TITLE
Moving schematic

### DIFF
--- a/src/circuits/.vscode/settings.json
+++ b/src/circuits/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#f7de1d",
+        "activityBar.background": "#f7de1d",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#059a89",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#f7de1d",
+        "statusBar.background": "#d9c108",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#a89506",
+        "statusBarItem.remoteBackground": "#d9c108",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#d9c108",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#d9c10899",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "#d9c108"
+}

--- a/src/circuits/circuits.ts
+++ b/src/circuits/circuits.ts
@@ -8,6 +8,6 @@ export const circuits = {
     'nMosSingle': nMosSingle(),
     'nMosDiffPair': nMosDiffPair(),
     'pMosSingle': pMosSingle(),
-    // 'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
+    'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
     // 'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),
 }

--- a/src/circuits/circuits.ts
+++ b/src/circuits/circuits.ts
@@ -5,9 +5,9 @@ import nMos9TransistorOpAmp from "./nMos9TransistorOpAmp"
 import pMosSingle from "./pMosSingle"
 
 export const circuits = {
-    'nMosSingle': nMosSingle(),
-    'nMosDiffPair': nMosDiffPair(),
+    // 'nMosSingle': nMosSingle(),
+    // 'nMosDiffPair': nMosDiffPair(),
     'pMosSingle': pMosSingle(),
-    'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
-    'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),
+    // 'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
+    // 'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),
 }

--- a/src/circuits/circuits.ts
+++ b/src/circuits/circuits.ts
@@ -5,7 +5,7 @@ import nMos9TransistorOpAmp from "./nMos9TransistorOpAmp"
 import pMosSingle from "./pMosSingle"
 
 export const circuits = {
-    // 'nMosSingle': nMosSingle(),
+    'nMosSingle': nMosSingle(),
     // 'nMosDiffPair': nMosDiffPair(),
     'pMosSingle': pMosSingle(),
     // 'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),

--- a/src/circuits/circuits.ts
+++ b/src/circuits/circuits.ts
@@ -9,5 +9,5 @@ export const circuits = {
     'nMosDiffPair': nMosDiffPair(),
     'pMosSingle': pMosSingle(),
     'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
-    // 'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),
+    'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),
 }

--- a/src/circuits/circuits.ts
+++ b/src/circuits/circuits.ts
@@ -6,7 +6,7 @@ import pMosSingle from "./pMosSingle"
 
 export const circuits = {
     'nMosSingle': nMosSingle(),
-    // 'nMosDiffPair': nMosDiffPair(),
+    'nMosDiffPair': nMosDiffPair(),
     'pMosSingle': pMosSingle(),
     // 'nMos5TransistorOpAmp': nMos5TransistorOpAmp(),
     // 'nMos9TransistorOpAmp': nMos9TransistorOpAmp(),

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -154,8 +154,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            tectonicPlateM1.transformations,
-            {x: -8, y: 3},
+            ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
             "V1",
@@ -163,16 +162,14 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             true
         ),
         "V2": new VoltageSource(
-            tectonicPlateM2.transformations,
-            {x: 8, y: 3},
+            ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
             "V2",
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformations,
-            {x: 4, y: 9},
+            ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
             "Vb",
@@ -228,8 +225,8 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes["M1_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -237,8 +234,8 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes["M2_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -246,8 +243,8 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes["Mb_gate"],
                 lines: [
-                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
-                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -2,11 +2,15 @@ import { Visibility } from '../types'
 import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 import { Circuit } from '../classes/circuit'
 import { Node } from '../classes/node'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { ParasiticCapacitor } from '../classes/parasiticCapacitor'
 import { Schematic } from '../classes/schematic'
 import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
+import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
+import { getPointAlongPath } from '../functions/drawFuncs'
+import { between } from '../functions/extraMath'
+import { GndSymbol, VddSymbol } from '../classes/powerSymbols'
 
 const useNmos5TransistorOpAmp = (): Circuit => {
     const circuit: Circuit = new Circuit({x: 0, y: 0}, 25, 28)
@@ -16,63 +20,50 @@ const useNmos5TransistorOpAmp = (): Circuit => {
     //////////////////////////////
 
     circuit.nodes = {
-        [gndNodeId]: ref(new Node(gndVoltage, true,
-            [
-                {start: {x: 0, y: 8}, end: {x: 0, y: 9}},
-            ]
-        )),
-        [vddNodeId]: ref(new Node(vddVoltage, true,
-            [
-                {start: {x: -4, y: -11}, end: {x: -4, y: -12}},
-                {start: {x: 4, y: -11}, end: {x: 4, y: -12}},
-            ]
-        )),
-        "M1_gate": ref(new Node(2, false,
-            [
-                {start: {x: -8, y: 1}, end: {x: -8, y: 0}},
-                {start: {x: -8, y: 0}, end: {x: -6, y: 0}},
-            ]
+        [gndNodeId]: ref(new Node(gndVoltage, true)),
+        [vddNodeId]: ref(new Node(vddVoltage, true)),
+        "M1_gate": ref(new Node(2, false)),
+        "M1_drain": ref(new Node(4, false)),
+        "M2_gate": ref(new Node(2, false)),
+        "Mb_gate": ref(new Node(0.7, false)),
+        "Vout": ref(new Node(4, false)),
+        "Vnode": ref(new Node(1, false)),
+    }
 
-        )),
-        "M1_drain": ref(new Node(4, false,
-            [
-                {start: {x: -4, y: -2}, end: {x: -4, y: -7}},
-                {start: {x: -4, y: -6}, end: {x: -1, y: -6}},
-                {start: {x: -1, y: -6}, end: {x: -1, y: -9}},
-                {start: {x: -2, y: -9}, end: {x: 2, y: -9}},
-            ]
-        )),
-        "M2_gate": ref(new Node(2, false,
-            [
-                {start: {x: 8, y: 1}, end: {x: 8, y: 0}},
-                {start: {x: 8, y: 0}, end: {x: 6, y: 0}},
-            ]
+        //////////////////////////////
+    ///    TECTONIC PLATES     ///
+    //////////////////////////////
 
-        )),
-        "Vout": ref(new Node(4, false,
-            [
-                {start: {x: 4, y: -2}, end: {x: 4, y: -7}},
-                {start: {x: 4, y: -5}, end: {x: 6, y: -5}},
-            ],
-            "Vout",
-            [{x: 6.5, y: -5}]
-        )),
-        "Mb_gate": ref(new Node(0.7, false,
-            [
-                {start: {x: 4, y: 7}, end: {x: 4, y: 6}},
-                {start: {x: 4, y: 6}, end: {x: 2, y: 6}},
-            ]
-        )),
-        "Vnode": ref(new Node(1, false,
-            [
-                {start: {x: -4, y: 2}, end: {x: -4, y: 3}},
-                {start: {x:  4, y: 2}, end: {x:  4, y: 3}},
-                {start: {x: -4, y: 3}, end: {x:  4, y: 3}},
-                {start: {x:  0, y: 3}, end: {x:  0, y: 4}},
-            ],
-            "V",
-            [{x: -1, y: 2.5}]
-        )),
+    const tectonicPlateM1: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M1_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateM2: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M2_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlatePmos: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return {x: 0, y: -4}
+    }))
+
+    const tectonicPlateVnode: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 0, y: -6}}],
+            between(gndVoltage, vddVoltage, circuit.nodes["Vnode"].value.voltage) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateVout: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 2}, end: {x: 0, y: -6}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["Vout"].value.voltage, circuit.nodes["M2_gate"].value.voltage - 1.25)) / (vddVoltage - gndVoltage))
+    }))
+
+
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(tectonicPlatePmos.transformations, {x: -5, y: -14}),
+        topRight: new TectonicPoint(tectonicPlatePmos.transformations, {x: 5, y: -14}),
+        bottomLeft: new TectonicPoint(circuit.transformations, {x: -5, y: 14}),
+        bottomRight: new TectonicPoint(circuit.transformations, {x: 5, y: 14}),
     }
 
     //////////////////////////////
@@ -96,7 +87,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             'nmos',
             -4,
             0,
@@ -111,7 +102,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             'nmos',
             4,
             0,
@@ -126,7 +117,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M3": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmos.transformations,
             'pmos',
             -4,
             -9,
@@ -141,7 +132,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M4": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmos.transformations,
             'pmos',
             4,
             -9,
@@ -163,7 +154,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -172,7 +163,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -195,18 +186,103 @@ const useNmos5TransistorOpAmp = (): Circuit => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}],
-        [{x: -4, y: -12}, {x: 4, y: -12}],
-        [new ParasiticCapacitor(
-            circuit.transformations,
-            circuit.nodes["Vout"],
-            {x: 6, y: -4},
-            [
-                {start: {x: 6, y: -5}, end: {x: 6, y: -4}},
-            ],
-        )],
+        [
+            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
+            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
+            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+        ],
+        [
+            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
+            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+        ],
+        [],
+        // [new ParasiticCapacitor(
+        //     tectonicPlateVout.transformations,
+        //     circuit.nodes["Vout"],
+        //     {x: 6, y: -4},
+        //     [
+        //         {start: {x: 6, y: -5}, end: {x: 6, y: -4}},
+        //     ],
+        // )],
         Object.values(circuit.devices.mosfets),
-        Object.values(circuit.nodes)
+        Object.values(circuit.nodes),
+        [
+            {
+                node: circuit.nodes[gndNodeId],
+                lines: [
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vs"), circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes[vddNodeId],
+                lines: [
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M1_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M2_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Mb_gate"],
+                lines: [
+                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
+                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Vnode"],
+                lines: [
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                ],
+                voltageDisplayLabel: "V",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]
+            },
+            {
+            node: circuit.nodes["M1_drain"],
+            lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vd")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vg")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            }, {
+            node: circuit.nodes["Vout"],
+            lines: [
+                    new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vd")),
+                    new TectonicLine(tectonicPlateVout.transformations, {x: 4, y: -5}, tectonicPlateVout.transformations, {x: 6, y: -5}),
+                ],
+                voltageDisplayLabel: "Vout",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlateVout.transformations, {x: 6.5, y: -5})]
+            },
+        ]
     )
 
     return circuit

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -30,7 +30,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
         "Vnode": ref(new Node(1, false)),
     }
 
-        //////////////////////////////
+    //////////////////////////////
     ///    TECTONIC PLATES     ///
     //////////////////////////////
 

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -193,15 +193,14 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             new VddSymbol(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vdd")),
             new VddSymbol(...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vdd")),
         ],
-        [],
-        // [new ParasiticCapacitor(
-        //     tectonicPlateVout.transformations,
-        //     circuit.nodes["Vout"],
-        //     {x: 6, y: -4},
-        //     [
-        //         {start: {x: 6, y: -5}, end: {x: 6, y: -4}},
-        //     ],
-        // )],
+        [new ParasiticCapacitor(
+            tectonicPlateVout.transformations,
+            circuit.nodes["Vout"],
+            {x: 6, y: -4},
+            [
+                {start: {x: 6, y: -5}, end: {x: 6, y: -4}},
+            ],
+        )],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
         [

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -81,7 +81,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
 
     circuit.devices.mosfets = {
         "Mb": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             0,
             6,
@@ -96,7 +96,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             -4,
             0,
@@ -111,7 +111,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             4,
             0,
@@ -126,7 +126,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M3": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             -4,
             -9,
@@ -141,7 +141,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             Visibility.Locked,
         ),
         "M4": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             4,
             -9,
@@ -163,7 +163,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -172,7 +172,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -180,7 +180,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 4, y: 9},
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
@@ -194,11 +194,11 @@ const useNmos5TransistorOpAmp = (): Circuit => {
     //////////////////////////////
 
     circuit.schematic = new Schematic(
-        circuit.transformationMatrix,
+        circuit.transformations,
         [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}],
         [{x: -4, y: -12}, {x: 4, y: -12}],
         [new ParasiticCapacitor(
-            circuit.transformationMatrix,
+            circuit.transformations,
             circuit.nodes["Vout"],
             {x: 6, y: -4},
             [

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -187,14 +187,14 @@ const useNmos5TransistorOpAmp = (): Circuit => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [
-            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
-            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
-            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
-            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
         ],
         [
-            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
-            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vdd")),
         ],
         [],
         // [new ParasiticCapacitor(
@@ -211,7 +211,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes[gndNodeId],
                 lines: [
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vs"), circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Gnd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -219,8 +219,8 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes[vddNodeId],
                 lines: [
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vdd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -255,10 +255,10 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
                 node: circuit.nodes["Vnode"],
                 lines: [
-                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
-                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vs")),
                     new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
                 ],
                 voltageDisplayLabel: "V",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]
@@ -266,17 +266,17 @@ const useNmos5TransistorOpAmp = (): Circuit => {
             {
             node: circuit.nodes["M1_drain"],
             lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vd")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vg")),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vd")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_gate"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_drain"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vg")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
             }, {
             node: circuit.nodes["Vout"],
             lines: [
-                    new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vd")),
+                    new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vd")),
                     new TectonicLine(tectonicPlateVout.transformations, {x: 4, y: -5}, tectonicPlateVout.transformations, {x: 6, y: -5}),
                 ],
                 voltageDisplayLabel: "Vout",

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -2,11 +2,15 @@ import { Visibility } from '../types'
 import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 import { Circuit } from '../classes/circuit'
 import { Node } from '../classes/node'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 // import { ParasiticCapacitor } from '../classes/parasiticCapacitor'
 import { Schematic } from '../classes/schematic'
 import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
+import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
+import { getPointAlongPath } from '../functions/drawFuncs'
+import { between } from '../functions/extraMath'
+import { GndSymbol, VddSymbol } from '../classes/powerSymbols'
 
 
 const useNmos9TransistorOpAmp = () => {
@@ -17,83 +21,59 @@ const useNmos9TransistorOpAmp = () => {
     //////////////////////////////
 
     circuit.nodes = {
-        [gndNodeId]: ref(new Node(gndVoltage, true,
-            [
-                {start: {x: 0, y: 8}, end: {x: 0, y: 9}},
-                {start: {x: 24, y: 8}, end: {x: 24, y: 9}},
-                {start: {x: 16, y: 8}, end: {x: 16, y: 9}},
-            ]
-        )),
-        [vddNodeId]: ref(new Node(vddVoltage, true,
-            [
-                {start: {x: -4, y: -14}, end: {x: -4, y: -15}},
-                {start: {x: 4, y: -9}, end: {x: 4, y: -10}},
-                {start: {x: 16, y: -9}, end: {x: 16, y: -10}},
-                {start: {x: 24, y: -14}, end: {x: 24, y: -15}},
-            ]
-        )),
-        "M1_gate": ref(new Node(2, false,
-            [
-                {start: {x: -8, y: 1}, end: {x: -8, y: 0}},
-                {start: {x: -8, y: 0}, end: {x: -6, y: 0}},
-            ]
+        [gndNodeId]: ref(new Node(gndVoltage, true)),
+        [vddNodeId]: ref(new Node(vddVoltage, true)),
+        "M1_gate": ref(new Node(2, false)),
+        "M1_drain": ref(new Node(4, false)),
+        "M2_gate": ref(new Node(2, false)),
+        "M2_drain": ref(new Node(4, false)),
+        "M7_drain": ref(new Node(1, false)),
+        "Mb_gate": ref(new Node(0.7, false)),
+        "Vout": ref(new Node(4, false)),
+        "Vnode": ref(new Node(1, false)),
+    }
 
-        )),
-        "M1_drain": ref(new Node(4, false,
-            [
-                {start: {x: -4, y: -2}, end: {x: -4, y: -10}},
-                {start: {x: -4, y: -9}, end: {x: -1, y: -9}},
-                {start: {x: -1, y: -9}, end: {x: -1, y: -12}},
-                {start: {x: -2, y: -12}, end: {x: 22, y: -12}},
-            ]
-        )),
-        "M2_gate": ref(new Node(2, false,
-            [
-                {start: {x: 8, y: 1}, end: {x: 8, y: 0}},
-                {start: {x: 8, y: 0}, end: {x: 6, y: 0}},
-            ]
+    //////////////////////////////
+    ///    TECTONIC PLATES     ///
+    //////////////////////////////
 
-        )),
-        "M2_drain": ref(new Node(4, false,
-            [
-                {start: {x: 4, y: -2}, end: {x: 4, y: -5}},
-                {start: {x: 4, y: -4}, end: {x: 7, y: -4}},
-                {start: {x: 7, y: -4}, end: {x: 7, y: -7}},
-                {start: {x: 6, y: -7}, end: {x: 14, y: -7}},
-            ]
-        )),
-        "M7_drain": ref(new Node(1, false,
-            [
-                {start: {x: 16, y: -5}, end: {x: 16, y: 4}},
-                {start: {x: 16, y: 3}, end: {x: 19, y: 3}},
-                {start: {x: 19, y: 3}, end: {x: 19, y: 6}},
-                {start: {x: 18, y: 6}, end: {x: 22, y: 6}},
-            ]
-        )),
-        "Vout": ref(new Node(2.5, false,
-            [
-                {start: {x: 24, y: 4}, end: {x: 24, y: -10}},
-                {start: {x: 24, y: -3}, end: {x: 26, y: -3}},
-            ],
-            "Vout",
-            [{x: 26.5, y: -3}]
-        )),
-        "Mb_gate": ref(new Node(1.1, false,
-            [
-                {start: {x: 4, y: 7}, end: {x: 4, y: 6}},
-                {start: {x: 4, y: 6}, end: {x: 2, y: 6}},
-            ]
-        )),
-        "Vnode": ref(new Node(1, false,
-            [
-                {start: {x: -4, y: 2}, end: {x: -4, y: 3}},
-                {start: {x:  4, y: 2}, end: {x:  4, y: 3}},
-                {start: {x: -4, y: 3}, end: {x:  4, y: 3}},
-                {start: {x:  0, y: 3}, end: {x:  0, y: 4}},
-            ],
-            "V",
-            [{x: -1, y: 2.5}]
-        )),
+    const tectonicPlateM1: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M1_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateM2: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M2_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlatePmos: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return {x: 0, y: -4}
+    }))
+
+    const tectonicPlateOutput: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return {x: 10, y: 0}
+    }))
+
+    const tectonicPlatePmosOutput: TectonicPlate = new TectonicPlate(tectonicPlatePmos.transformations, computed(() => {
+        return {x: 10, y: 0}
+    }))
+
+    const tectonicPlateVnode: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 0, y: -6}}],
+            between(gndVoltage, vddVoltage, circuit.nodes["Vnode"].value.voltage) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateVout: TectonicPlate = new TectonicPlate(tectonicPlateOutput.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 8.5}, end: {x: 0, y: -9}}],
+            between(gndVoltage, vddVoltage, circuit.nodes["Vout"].value.voltage) / (vddVoltage - gndVoltage))
+    }))
+
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(tectonicPlatePmos.transformations, {x: -5, y: -18}),
+        topRight: new TectonicPoint(tectonicPlatePmosOutput.transformations, {x: 25, y: -18}),
+        bottomLeft: new TectonicPoint(circuit.transformations, {x: -5, y: 14}),
+        bottomRight: new TectonicPoint(tectonicPlateOutput.transformations, {x: 25, y: 14}),
     }
 
     //////////////////////////////
@@ -117,7 +97,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             'nmos',
             -4,
             0,
@@ -132,7 +112,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             'nmos',
             4,
             0,
@@ -147,7 +127,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M3": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmos.transformations,
             'pmos',
             -4,
             -12,
@@ -162,7 +142,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M4": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmosOutput.transformations,
             'pmos',
             24,
             -12,
@@ -177,7 +157,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M5": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmos.transformations,
             'pmos',
             4,
             -7,
@@ -192,7 +172,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M6": new Mosfet(
-            circuit.transformations,
+            tectonicPlatePmosOutput.transformations,
             'pmos',
             16,
             -7,
@@ -207,7 +187,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M7": new Mosfet(
-            circuit.transformations,
+            tectonicPlateOutput.transformations,
             'nmos',
             16,
             6,
@@ -222,7 +202,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M8": new Mosfet(
-            circuit.transformations,
+            tectonicPlateOutput.transformations,
             'nmos',
             24,
             6,
@@ -244,7 +224,7 @@ const useNmos9TransistorOpAmp = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -253,7 +233,7 @@ const useNmos9TransistorOpAmp = () => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -276,11 +256,126 @@ const useNmos9TransistorOpAmp = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}, {x: 24, y: 9}, {x: 16, y: 9}],
-        [{x: -4, y: -15}, {x: 4, y: -10}, {x: 16, y: -10}, {x: 24, y: -15}],
+        [
+            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+            new GndSymbol(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Gnd")),
+            new GndSymbol(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Gnd")),
+            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
+            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
+            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+        ],
+        [
+            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
+            new VddSymbol(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vdd")),
+            new VddSymbol(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vdd")),
+        ],
         [],
         Object.values(circuit.devices.mosfets),
-        Object.values(circuit.nodes)
+        Object.values(circuit.nodes),
+        [
+            {
+                node: circuit.nodes[gndNodeId],
+                lines: [
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vs"), circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+                    new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vs"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Gnd")),
+                    new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vs"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Gnd")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes[vddNodeId],
+                lines: [
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
+                    new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vs"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vdd")),
+                    new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vs"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vdd")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M1_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M2_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Mb_gate"],
+                lines: [
+                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
+                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Vnode"],
+                lines: [
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                ],
+                voltageDisplayLabel: "V",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]
+            },
+            {
+            node: circuit.nodes["M1_drain"],
+            lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vd")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
+                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vg")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M2_drain"],
+                lines: [
+                        new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vd")),
+                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vg")),
+                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_corner")),
+                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_corner")),
+                    ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M7_drain"],
+                lines: [
+                        new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vd"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vd")),
+                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vg")),
+                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_gate"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_corner")),
+                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_drain"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_corner")),
+                    ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Vout"],
+                lines: [
+                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vd"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vd")),
+                        new TectonicLine(tectonicPlateVout.transformations, {x: 24, y: -5}, tectonicPlateVout.transformations, {x: 28, y: -5}),
+                    ],
+                voltageDisplayLabel: "Vout",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlateVout.transformations, {x: 28.5, y: -5})]
+            },
+        ]
     )
     return circuit
 }

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -102,7 +102,7 @@ const useNmos9TransistorOpAmp = () => {
 
     circuit.devices.mosfets = {
         "Mb": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             0,
             6,
@@ -117,7 +117,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             -4,
             0,
@@ -132,7 +132,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             4,
             0,
@@ -147,7 +147,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M3": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             -4,
             -12,
@@ -162,7 +162,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M4": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             24,
             -12,
@@ -177,7 +177,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M5": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             4,
             -7,
@@ -192,7 +192,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M6": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'pmos',
             16,
             -7,
@@ -207,7 +207,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M7": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             16,
             6,
@@ -222,7 +222,7 @@ const useNmos9TransistorOpAmp = () => {
             Visibility.Locked,
         ),
         "M8": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             24,
             6,
@@ -244,7 +244,7 @@ const useNmos9TransistorOpAmp = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -253,7 +253,7 @@ const useNmos9TransistorOpAmp = () => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -261,7 +261,7 @@ const useNmos9TransistorOpAmp = () => {
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 4, y: 9},
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
@@ -275,7 +275,7 @@ const useNmos9TransistorOpAmp = () => {
     //////////////////////////////
 
     circuit.schematic = new Schematic(
-        circuit.transformationMatrix,
+        circuit.transformations,
         [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}, {x: 24, y: 9}, {x: 16, y: 9}],
         [{x: -4, y: -15}, {x: 4, y: -10}, {x: 16, y: -10}, {x: 24, y: -15}],
         [],

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -70,10 +70,10 @@ const useNmos9TransistorOpAmp = () => {
     }))
 
     circuit.boundingBox = {
-        topLeft: new TectonicPoint(tectonicPlatePmos.transformations, {x: -5, y: -18}),
-        topRight: new TectonicPoint(tectonicPlatePmosOutput.transformations, {x: 25, y: -18}),
-        bottomLeft: new TectonicPoint(circuit.transformations, {x: -5, y: 14}),
-        bottomRight: new TectonicPoint(tectonicPlateOutput.transformations, {x: 25, y: 14}),
+        topLeft: new TectonicPoint(tectonicPlatePmos.transformations, {x: -12, y: -18}),
+        topRight: new TectonicPoint(tectonicPlatePmosOutput.transformations, {x: 33, y: -18}),
+        bottomLeft: new TectonicPoint(circuit.transformations, {x: -12, y: 14}),
+        bottomRight: new TectonicPoint(tectonicPlateOutput.transformations, {x: 33, y: 14}),
     }
 
     //////////////////////////////

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -224,8 +224,7 @@ const useNmos9TransistorOpAmp = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            tectonicPlateM1.transformations,
-            {x: -8, y: 3},
+            ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
             "V1",
@@ -233,16 +232,14 @@ const useNmos9TransistorOpAmp = () => {
             true
         ),
         "V2": new VoltageSource(
-            tectonicPlateM2.transformations,
-            {x: 8, y: 3},
+            ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
             "V2",
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformations,
-            {x: 4, y: 9},
+            ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
             "Vb",
@@ -298,8 +295,8 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["M1_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -307,8 +304,8 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["M2_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -316,8 +313,8 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["Mb_gate"],
                 lines: [
-                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
-                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -257,18 +257,18 @@ const useNmos9TransistorOpAmp = () => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [
-            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
-            new GndSymbol(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Gnd")),
-            new GndSymbol(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Gnd")),
-            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
-            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
-            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+            new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Gnd")),
+            new GndSymbol(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Gnd")),
+            new GndSymbol(...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
         ],
         [
-            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
-            new VddSymbol(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
-            new VddSymbol(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vdd")),
-            new VddSymbol(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M6"].getAnchorPointWithTransformations("Vdd")),
         ],
         [],
         Object.values(circuit.devices.mosfets),
@@ -277,9 +277,9 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes[gndNodeId],
                 lines: [
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vs"), circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
-                    new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vs"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Gnd")),
-                    new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vs"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Gnd")),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Gnd")),
+                    new TectonicLine(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Gnd")),
+                    new TectonicLine(...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Gnd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -287,10 +287,10 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes[vddNodeId],
                 lines: [
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vdd")),
-                    new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vs"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vdd")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vs"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vdd")),
-                    new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vs"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M6"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M6"].getAnchorPointWithTransformations("Vdd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -325,10 +325,10 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["Vnode"],
                 lines: [
-                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
-                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vs")),
                     new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
                 ],
                 voltageDisplayLabel: "V",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]
@@ -336,10 +336,10 @@ const useNmos9TransistorOpAmp = () => {
             {
             node: circuit.nodes["M1_drain"],
             lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vd")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg_mirror_corner")),
-                    new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M3"].getAnchorPoint("Vg"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vg")),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vd")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_gate"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_drain"), ...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                    new TectonicLine(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vg")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -347,10 +347,10 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["M2_drain"],
                 lines: [
-                        new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vd")),
-                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vg")),
-                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_gate"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_corner")),
-                        new TectonicLine(tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_drain"), tectonicPlatePmos.transformations, circuit.devices.mosfets["M5"].getAnchorPoint("Vg_mirror_corner")),
+                        new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vd")),
+                        new TectonicLine(...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M6"].getAnchorPointWithTransformations("Vg")),
+                        new TectonicLine(...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vg_mirror_gate"), ...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                        new TectonicLine(...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vg_mirror_drain"), ...circuit.devices.mosfets["M5"].getAnchorPointWithTransformations("Vg_mirror_corner")),
                     ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -358,10 +358,10 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["M7_drain"],
                 lines: [
-                        new TectonicLine(tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M6"].getAnchorPoint("Vd"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vd")),
-                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vg")),
-                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_gate"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_corner")),
-                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_drain"), tectonicPlateOutput.transformations, circuit.devices.mosfets["M7"].getAnchorPoint("Vg_mirror_corner")),
+                        new TectonicLine(...circuit.devices.mosfets["M6"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vd")),
+                        new TectonicLine(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Vg")),
+                        new TectonicLine(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vg_mirror_gate"), ...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vg_mirror_corner")),
+                        new TectonicLine(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vg_mirror_drain"), ...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vg_mirror_corner")),
                     ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -369,7 +369,7 @@ const useNmos9TransistorOpAmp = () => {
             {
                 node: circuit.nodes["Vout"],
                 lines: [
-                        new TectonicLine(tectonicPlateOutput.transformations, circuit.devices.mosfets["M8"].getAnchorPoint("Vd"), tectonicPlatePmosOutput.transformations, circuit.devices.mosfets["M4"].getAnchorPoint("Vd")),
+                        new TectonicLine(...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M4"].getAnchorPointWithTransformations("Vd")),
                         new TectonicLine(tectonicPlateVout.transformations, {x: 24, y: -5}, tectonicPlateVout.transformations, {x: 28, y: -5}),
                     ],
                 voltageDisplayLabel: "Vout",

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -147,14 +147,14 @@ const useNmosDiffPair = () => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [
-            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
-            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
-            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
-            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
         ],
         [
-            new VddSymbol(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vdd")),
-            new VddSymbol(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vdd")),
+            new VddSymbol(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vdd")),
         ],
         [],
         Object.values(circuit.devices.mosfets),
@@ -171,8 +171,8 @@ const useNmosDiffPair = () => {
             {
                 node: circuit.nodes[vddNodeId],
                 lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vdd")),
-                    new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vdd")),
+                    new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vdd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -207,10 +207,10 @@ const useNmosDiffPair = () => {
             {
                 node: circuit.nodes["Vnode"],
                 lines: [
-                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
-                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vs")),
                     new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
                 ],
                 voltageDisplayLabel: "V",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -114,8 +114,7 @@ const useNmosDiffPair = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            tectonicPlateM1.transformations,
-            {x: -8, y: 3},
+            ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
             "V1",
@@ -123,16 +122,14 @@ const useNmosDiffPair = () => {
             true
         ),
         "V2": new VoltageSource(
-            tectonicPlateM2.transformations,
-            {x: 8, y: 3},
+            ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
             "V2",
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformations,
-            {x: 4, y: 9},
+            ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_Vsource"),
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
             "Vb",
@@ -180,8 +177,8 @@ const useNmosDiffPair = () => {
             {
                 node: circuit.nodes["M1_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
-                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -189,8 +186,8 @@ const useNmosDiffPair = () => {
             {
                 node: circuit.nodes["M2_gate"],
                 lines: [
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
-                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                    new TectonicLine(...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["M2"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []
@@ -198,8 +195,8 @@ const useNmosDiffPair = () => {
             {
                 node: circuit.nodes["Mb_gate"],
                 lines: [
-                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
-                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                    new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vplus"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vg_drive_gate")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -67,7 +67,7 @@ const useNmosDiffPair = () => {
 
     circuit.devices.mosfets = {
         "Mb": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             0,
             6,
@@ -82,7 +82,7 @@ const useNmosDiffPair = () => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             -4,
             0,
@@ -97,7 +97,7 @@ const useNmosDiffPair = () => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             4,
             0,
@@ -119,7 +119,7 @@ const useNmosDiffPair = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -128,7 +128,7 @@ const useNmosDiffPair = () => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -136,7 +136,7 @@ const useNmosDiffPair = () => {
             'gnd'
         ),
         "Vb": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 4, y: 9},
             circuit.nodes[gndNodeId],
             circuit.nodes["Mb_gate"],
@@ -150,7 +150,7 @@ const useNmosDiffPair = () => {
     //////////////////////////////
 
     circuit.schematic = new Schematic(
-        circuit.transformationMatrix,
+        circuit.transformations,
         [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}],
         [{x: -4, y: -3}, {x: 4, y: -3}],
         [],

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -2,11 +2,15 @@ import { Visibility } from '../types'
 import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 import { Circuit } from '../classes/circuit'
 import { Node } from '../classes/node'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 // import { ParasiticCapacitor } from '../classes/parasiticCapacitor'
 import { Schematic } from '../classes/schematic'
 import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
+import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
+import { getPointAlongPath } from '../functions/drawFuncs'
+import { between } from '../functions/extraMath'
+import { GndSymbol, VddSymbol } from '../classes/powerSymbols'
 
 const useNmosDiffPair = () => {
     const circuit: Circuit = new Circuit({x: 0, y: 4}, 25, 20)
@@ -16,50 +20,41 @@ const useNmosDiffPair = () => {
     //////////////////////////////
 
     circuit.nodes = {
-        [gndNodeId]: ref(new Node(gndVoltage, true,
-            [
-                {start: {x: 0, y: 8}, end: {x: 0, y: 9}},
-            ]
-        )),
-        [vddNodeId]: ref(new Node(vddVoltage, true,
-            [
-                {start: {x: -4, y: -2}, end: {x: -4, y: -3}},
-                {start: {x: 4, y: -2}, end: {x: 4, y: -3}},
-            ]
-        )),
-        "M1_gate": ref(new Node(2, false,
-            [
-                {start: {x: -8, y: 1}, end: {x: -8, y: 0}},
-                {start: {x: -8, y: 0}, end: {x: -6, y: 0}},
-            ]
-
-        )),
-        // "M1_drain": makeNode(5, false),
-        "M2_gate": ref(new Node(2, false,
-            [
-                {start: {x: 8, y: 1}, end: {x: 8, y: 0}},
-                {start: {x: 8, y: 0}, end: {x: 6, y: 0}},
-            ]
-
-        )),
-        // "M2_drain": makeNode(5, false),
-        "Mb_gate": ref(new Node(0.7, false,
-            [
-                {start: {x: 4, y: 7}, end: {x: 4, y: 6}},
-                {start: {x: 4, y: 6}, end: {x: 2, y: 6}},
-            ]
-        )),
-        "Vnode": ref(new Node(1, false,
-            [
-                {start: {x: -4, y: 2}, end: {x: -4, y: 3}},
-                {start: {x:  4, y: 2}, end: {x:  4, y: 3}},
-                {start: {x: -4, y: 3}, end: {x:  4, y: 3}},
-                {start: {x:  0, y: 3}, end: {x:  0, y: 4}},
-            ],
-            "V",
-            [{x: -1, y: 2.5}]
-        )),
+        [gndNodeId]: ref(new Node(gndVoltage, true)),
+        [vddNodeId]: ref(new Node(vddVoltage, true)),
+        "M1_gate": ref(new Node(2, false)),
+        "M2_gate": ref(new Node(2, false)),
+        "Mb_gate": ref(new Node(0.7, false)),
+        "Vnode": ref(new Node(1, false)),
     }
+
+    //////////////////////////////
+    ///    TECTONIC PLATES     ///
+    //////////////////////////////
+
+    const tectonicPlateM1: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M1_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateM2: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 1}, end: {x: 0, y: -7}}],
+            between(gndVoltage, vddVoltage, Math.max(circuit.nodes["M2_gate"].value.voltage, circuit.nodes["Vnode"].value.voltage)) / (vddVoltage - gndVoltage))
+    }))
+
+    const tectonicPlateVnode: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 0, y: -6}}],
+            between(gndVoltage, vddVoltage, circuit.nodes["Vnode"].value.voltage) / (vddVoltage - gndVoltage))
+    }))
+
+
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(tectonicPlateM1.transformations, {x: -5, y: -6}),
+        topRight: new TectonicPoint(tectonicPlateM2.transformations, {x: 5, y: -6}),
+        bottomLeft: new TectonicPoint(circuit.transformations, {x: -5, y: 12}),
+        bottomRight: new TectonicPoint(circuit.transformations, {x: 5, y: 12}),
+    }
+
 
     //////////////////////////////
     ///         MOSFETS        ///
@@ -82,7 +77,7 @@ const useNmosDiffPair = () => {
             Visibility.Locked
         ),
         "M1": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             'nmos',
             -4,
             0,
@@ -97,7 +92,7 @@ const useNmosDiffPair = () => {
             Visibility.Locked,
         ),
         "M2": new Mosfet(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             'nmos',
             4,
             0,
@@ -119,7 +114,7 @@ const useNmosDiffPair = () => {
 
     circuit.devices.voltageSources = {
         "V1": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM1.transformations,
             {x: -8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_gate"],
@@ -128,7 +123,7 @@ const useNmosDiffPair = () => {
             true
         ),
         "V2": new VoltageSource(
-            circuit.transformations,
+            tectonicPlateM2.transformations,
             {x: 8, y: 3},
             circuit.nodes[gndNodeId],
             circuit.nodes["M2_gate"],
@@ -151,11 +146,76 @@ const useNmosDiffPair = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [{x: 0, y: 9}, {x: 4, y: 11}, {x: -8, y: 5}, {x: 8, y: 5}],
-        [{x: -4, y: -3}, {x: 4, y: -3}],
+        [
+            new GndSymbol(circuit.transformations, circuit.devices.voltageSources["Vb"].getAnchorPoint("Vminus")),
+            new GndSymbol(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Gnd")),
+            new GndSymbol(tectonicPlateM1.transformations, circuit.devices.voltageSources["V1"].getAnchorPoint("Vminus")),
+            new GndSymbol(tectonicPlateM2.transformations, circuit.devices.voltageSources["V2"].getAnchorPoint("Vminus")),
+        ],
+        [
+            new VddSymbol(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vdd")),
+            new VddSymbol(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vdd")),
+        ],
         [],
         Object.values(circuit.devices.mosfets),
-        Object.values(circuit.nodes)
+        Object.values(circuit.nodes),
+        [
+            {
+                node: circuit.nodes[gndNodeId],
+                lines: [
+                    new TectonicLine(circuit.transformations, {x: 0, y: 8}, circuit.transformations, {x: 0, y: 9}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes[vddNodeId],
+                lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vdd")),
+                    new TectonicLine(tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vd"), tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vdd")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M1_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 1}, tectonicPlateM1.transformations, {x: -8, y: 0}),
+                    new TectonicLine(tectonicPlateM1.transformations, {x: -8, y: 0}, tectonicPlateM1.transformations, {x: -6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["M2_gate"],
+                lines: [
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 1}, tectonicPlateM2.transformations, {x: 8, y: 0}),
+                    new TectonicLine(tectonicPlateM2.transformations, {x: 8, y: 0}, tectonicPlateM2.transformations, {x: 6, y: 0}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Mb_gate"],
+                lines: [
+                    new TectonicLine(circuit.transformations, {x: 4, y: 7}, circuit.transformations, {x: 4, y: 6}),
+                    new TectonicLine(circuit.transformations, {x: 4, y: 6}, circuit.transformations, {x: 2, y: 6}),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
+            },
+            {
+                node: circuit.nodes["Vnode"],
+                lines: [
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateM1.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x:  4, y: 3}, tectonicPlateM2.transformations, circuit.devices.mosfets["M2"].getAnchorPoint("Vs")),
+                    new TectonicLine(tectonicPlateVnode.transformations, {x: -4, y: 3}, tectonicPlateVnode.transformations, {x:  4, y: 3}),
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["Mb"].getAnchorPoint("Vd"), tectonicPlateVnode.transformations, {x:  0, y: 3}),
+                ],
+                voltageDisplayLabel: "V",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlateVnode.transformations, {x: -1, y: 2.5})]
+            }
+        ]
     )
 
     return circuit

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -33,7 +33,7 @@ const useNmosSingle = () => {
 
     circuit.devices.mosfets = {
         "M1": new Mosfet(
-            circuit.transformationMatrix,
+            circuit.transformations,
             'nmos',
             0,
             0,
@@ -50,7 +50,7 @@ const useNmosSingle = () => {
 
     circuit.devices.voltageSources = {
         "Vd": new VoltageSource(
-            circuit.transformationMatrix,
+            circuit.transformations,
             {x: 0, y: -6},
             circuit.nodes["M1_drain"],
             circuit.nodes[vddNodeId],
@@ -65,7 +65,7 @@ const useNmosSingle = () => {
     //////////////////////////////
 
     circuit.schematic = new Schematic(
-        circuit.transformationMatrix,
+        circuit.transformations,
         [{x: 0, y: 2}],
         [{x: 0, y: -8}],
         [],

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -93,7 +93,7 @@ const useNmosSingle = () => {
                     new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus")),
                 ],
                 voltageDisplayLabel: "Drain",
-                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: -3})]
             },
         ]
     )

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -81,8 +81,8 @@ const useNmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [new GndSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs"))],
-        [new VddSymbol(tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vplus"))],
+        [new GndSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs"))],
+        [new VddSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus"))],
         [],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
@@ -90,7 +90,7 @@ const useNmosSingle = () => {
             {
                 node: circuit.nodes["M1_drain"],
                 lines: [
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vminus")),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus")),
                 ],
                 voltageDisplayLabel: "Drain",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -2,11 +2,15 @@
 import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 import { Circuit } from '../classes/circuit'
 import { Node } from '../classes/node'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 // import { ParasiticCapacitor } from '../classes/parasiticCapacitor'
 import { Schematic } from '../classes/schematic'
 import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
+import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
+import { getPointAlongPath } from '../functions/drawFuncs'
+import { between } from '../functions/extraMath'
+import { GndSymbol, VddSymbol } from '../classes/powerSymbols'
 
 const useNmosSingle = () => {
     const circuit: Circuit = new Circuit({x: 0, y: -3}, 10, 20)
@@ -18,13 +22,24 @@ const useNmosSingle = () => {
     circuit.nodes = {
         [gndNodeId]: ref(new Node(gndVoltage, true)),
         [vddNodeId]: ref(new Node(vddVoltage, true)),
-        "M1_drain": ref(new Node(5, false,
-            [
-                {start: {x: 0, y: -2}, end: {x: 0, y: -4}},
-            ]
-        )),
+        "M1_drain": ref(new Node(5, false)),
         "M1_gate": ref(new Node(1, false)),
+    }
 
+    //////////////////////////////
+    ///    TECTONIC PLATES     ///
+    //////////////////////////////
+
+    const tectonicPlate: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 0, y: -6}}],
+            between(gndVoltage, vddVoltage, circuit.nodes["M1_drain"].value.voltage) / (vddVoltage - gndVoltage))
+    }))
+
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: -12}),
+        topRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: -12}),
+        bottomLeft: new TectonicPoint(circuit.transformations, {x: -5, y: 6}),
+        bottomRight: new TectonicPoint(circuit.transformations, {x: 5, y: 6}),
     }
 
     //////////////////////////////
@@ -50,7 +65,7 @@ const useNmosSingle = () => {
 
     circuit.devices.voltageSources = {
         "Vd": new VoltageSource(
-            circuit.transformations,
+            tectonicPlate.transformations,
             {x: 0, y: -6},
             circuit.nodes["M1_drain"],
             circuit.nodes[vddNodeId],
@@ -66,11 +81,21 @@ const useNmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [{x: 0, y: 2}],
-        [{x: 0, y: -8}],
+        [new GndSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs"))],
+        [new VddSymbol(tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vplus"))],
         [],
         Object.values(circuit.devices.mosfets),
-        Object.values(circuit.nodes)
+        Object.values(circuit.nodes),
+        [
+            {
+                node: circuit.nodes["M1_drain"],
+                lines: [
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vminus")),
+                ],
+                voltageDisplayLabel: "Drain",
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
+            },
+        ]
     )
 
     return circuit

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -70,9 +70,6 @@ const usePmosSingle = () => {
     ///        SCHEMATIC       ///
     //////////////////////////////
 
-    console.log("tectonicPlate.transformations", tectonicPlate.transformationMatrix.translation)
-    console.log("circuit.transformations", circuit.transformationMatrix.translation)
-    console.log("circuit.devices.mosfets['M1'].getAnchorPoint('Vd'))", circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))
     circuit.schematic = new Schematic(
         circuit.transformations,
         [new GndSymbol(circuit.transformations, {x: 0, y: 8})],
@@ -87,7 +84,7 @@ const usePmosSingle = () => {
                     new TectonicLine(tectonicPlate.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
                 ],
                 voltageDisplayLabel: "Drain",
-                voltageDisplayLocations: [new TectonicPoint(circuit.transformations, {x: 0, y: 3})]
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
             }
         ]
     )

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -81,7 +81,7 @@ const usePmosSingle = () => {
             {
                 node: circuit.nodes["M1_drain"],
                 lines: [
-                    new TectonicLine(circuit.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
+                    new TectonicLine(tectonicPlate.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
                 ],
                 voltageDisplayLabel: "Drain",
                 voltageDisplayLocations: [new TectonicPoint(circuit.transformations, {x: 0, y: 3})]

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -70,6 +70,9 @@ const usePmosSingle = () => {
     ///        SCHEMATIC       ///
     //////////////////////////////
 
+    console.log("tectonicPlate.transformations", tectonicPlate.transformationMatrix.translation)
+    console.log("circuit.transformations", circuit.transformationMatrix.translation)
+    console.log("circuit.devices.mosfets['M1'].getAnchorPoint('Vd'))", circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))
     circuit.schematic = new Schematic(
         circuit.transformations,
         [new GndSymbol(circuit.transformations, {x: 0, y: 8})],

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -12,6 +12,7 @@ import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicP
 import { getPointAlongPath } from '../functions/drawFuncs'
 import { GndSymbol } from '../classes/powerSymbols'
 import { VddSymbol } from '../classes/powerSymbols'
+import { TransformationMatrix } from '../classes/transformationMatrix'
 
 const usePmosSingle = () => {
     const circuit: Circuit = new Circuit({x: 0, y: 3}, 10, 20)
@@ -94,10 +95,10 @@ const usePmosSingle = () => {
     )
 
     circuit.boundingBox = {
-        topLeft: new TectonicPoint(circuit.transformations, {x: -5, y: -4}),
-        topRight: new TectonicPoint(circuit.transformations, {x: 5, y: -4}),
-        bottomLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 16}),
-        bottomRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 16}),
+        topLeft: new TectonicPoint(circuit.transformations, {x: -5, y: -6}),
+        topRight: new TectonicPoint(circuit.transformations, {x: 5, y: -6}),
+        bottomLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 12}),
+        bottomRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 12}),
     }
 
     return circuit

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -81,8 +81,8 @@ const usePmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [new GndSymbol(tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vminus"))],
-        [new VddSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs"))],
+        [new GndSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus"))],
+        [new VddSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs"))],
         [],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
@@ -90,7 +90,7 @@ const usePmosSingle = () => {
             {
                 node: circuit.nodes["M1_drain"],
                 lines: [
-                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vplus")),
+                    new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus")),
                 ],
                 voltageDisplayLabel: "Drain",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -90,8 +90,6 @@ const usePmosSingle = () => {
     //////////////////////////////
 
     circuit.updateDevicePositions = (_circuit: Circuit) => {
-        // _circuit.devices.mosfets["M1"].moveTo(_circuit.devices.mosfets["M1"].transformationMatrix.inverse().multiply(_circuit.transformationMatrix).transformPoint({x: 0, y: _circuit.devices.mosfets["M1"].Vd.value.voltage * -1}))
-        // // _circuit.devices.mosfets["M1"]._transformationMatrix = ref(foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(),  _circuit.devices.mosfets["M1"].transformations)) as Ref<TransformationMatrix>
         tectonicPlate.moveTowardDesiredLocation()
     }
 

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -9,7 +9,7 @@ import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
 import { between, foldl } from '../functions/extraMath'
 import { TransformationMatrix } from '../classes/transformationMatrix'
-import { TectonicPlate } from '../classes/tectonicPlate'
+import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
 import { getPointAlongPath } from '../functions/drawFuncs'
 import { GndSymbol } from '../classes/powerSymbols'
 import { VddSymbol } from '../classes/powerSymbols'
@@ -26,7 +26,7 @@ const usePmosSingle = () => {
         [vddNodeId]: ref(new Node(vddVoltage, true)),
         "M1_drain": ref(new Node(5, false,
             [
-                {start: {x: 0, y: 2}, end: {x: 0, y: 4}}
+                new TectonicLine(circuit.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
             ]
         )),
         "M1_gate": ref(new Node(1, false)),

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -27,8 +27,12 @@ const usePmosSingle = () => {
         "M1_gate": ref(new Node(1, false)),
     }
 
+    //////////////////////////////
+    ///    TECTONIC PLATES     ///
+    //////////////////////////////
+
     const tectonicPlate: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
-        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 3, y: 6}}],
+        return getPointAlongPath([{start: {x: 0, y: 6}, end: {x: 0, y: 0}}],
             between(gndVoltage, vddVoltage, circuit.nodes["M1_drain"].value.voltage) / (vddVoltage - gndVoltage))
     }))
 
@@ -39,7 +43,7 @@ const usePmosSingle = () => {
     circuit.devices.mosfets = {
         "M1": new Mosfet(
             // circuit.transformations,
-            tectonicPlate.transformations,
+            circuit.transformations,
             'pmos',
             0,
             0,
@@ -56,7 +60,7 @@ const usePmosSingle = () => {
 
     circuit.devices.voltageSources = {
         "Vd": new VoltageSource(
-            circuit.transformations,
+            tectonicPlate.transformations,
             {x: 0, y: 6},
             circuit.nodes[gndNodeId],
             circuit.nodes["M1_drain"],
@@ -72,8 +76,8 @@ const usePmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [new GndSymbol(circuit.transformations, {x: 0, y: 8})],
-        [new VddSymbol(tectonicPlate.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))],
+        [new GndSymbol(tectonicPlate.transformations, {x: 0, y: 8})],
+        [new VddSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))],
         [],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
@@ -81,13 +85,20 @@ const usePmosSingle = () => {
             {
                 node: circuit.nodes["M1_drain"],
                 lines: [
-                    new TectonicLine(tectonicPlate.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
+                    new TectonicLine(circuit.transformations, {x: 0, y: 2}, tectonicPlate.transformations, {x: 0, y: 4}),
                 ],
                 voltageDisplayLabel: "Drain",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
             }
         ]
     )
+
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(circuit.transformations, {x: -5, y: -4}),
+        topRight: new TectonicPoint(circuit.transformations, {x: 5, y: -4}),
+        bottomLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 16}),
+        bottomRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 16}),
+    }
 
     return circuit
 }

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -10,9 +10,7 @@ import { VoltageSource } from '../classes/voltageSource'
 import { between } from '../functions/extraMath'
 import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
 import { getPointAlongPath } from '../functions/drawFuncs'
-import { GndSymbol } from '../classes/powerSymbols'
-import { VddSymbol } from '../classes/powerSymbols'
-import { TransformationMatrix } from '../classes/transformationMatrix'
+import { GndSymbol, VddSymbol } from '../classes/powerSymbols'
 
 const usePmosSingle = () => {
     const circuit: Circuit = new Circuit({x: 0, y: 3}, 10, 20)
@@ -37,13 +35,19 @@ const usePmosSingle = () => {
             between(gndVoltage, vddVoltage, circuit.nodes["M1_drain"].value.voltage) / (vddVoltage - gndVoltage))
     }))
 
+    circuit.boundingBox = {
+        topLeft: new TectonicPoint(circuit.transformations, {x: -5, y: -6}),
+        topRight: new TectonicPoint(circuit.transformations, {x: 5, y: -6}),
+        bottomLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 12}),
+        bottomRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 12}),
+    }
+
     //////////////////////////////
     ///         MOSFETS        ///
     //////////////////////////////
 
     circuit.devices.mosfets = {
         "M1": new Mosfet(
-            // circuit.transformations,
             circuit.transformations,
             'pmos',
             0,
@@ -77,8 +81,8 @@ const usePmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [new GndSymbol(tectonicPlate.transformations, {x: 0, y: 8})],
-        [new VddSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))],
+        [new GndSymbol(tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vminus"))],
+        [new VddSymbol(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vs"))],
         [],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
@@ -86,20 +90,13 @@ const usePmosSingle = () => {
             {
                 node: circuit.nodes["M1_drain"],
                 lines: [
-                    new TectonicLine(circuit.transformations, {x: 0, y: 2}, tectonicPlate.transformations, {x: 0, y: 4}),
+                    new TectonicLine(circuit.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"), tectonicPlate.transformations, circuit.devices.voltageSources["Vd"].getAnchorPoint("Vplus")),
                 ],
                 voltageDisplayLabel: "Drain",
                 voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
-            }
+            },
         ]
     )
-
-    circuit.boundingBox = {
-        topLeft: new TectonicPoint(circuit.transformations, {x: -5, y: -6}),
-        topRight: new TectonicPoint(circuit.transformations, {x: 5, y: -6}),
-        bottomLeft: new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 12}),
-        bottomRight: new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 12}),
-    }
 
     return circuit
 }

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -93,7 +93,7 @@ const usePmosSingle = () => {
                     new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus")),
                 ],
                 voltageDisplayLabel: "Drain",
-                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0, y: 3})]
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: 3})]
             },
         ]
     )

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -11,6 +11,8 @@ import { between, foldl } from '../functions/extraMath'
 import { TransformationMatrix } from '../classes/transformationMatrix'
 import { TectonicPlate } from '../classes/tectonicPlate'
 import { getPointAlongPath } from '../functions/drawFuncs'
+import { GndSymbol } from '../classes/powerSymbols'
+import { VddSymbol } from '../classes/powerSymbols'
 
 const usePmosSingle = () => {
     const circuit: Circuit = new Circuit({x: 0, y: 3}, 10, 20)
@@ -75,8 +77,8 @@ const usePmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [{x: 0, y: 8}],
-        [circuit.devices.mosfets["M1"].getAnchorPoint("Vg")],
+        [new GndSymbol(circuit.transformations, {x: 0, y: 8})],
+        [new VddSymbol(tectonicPlate.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))],
         // [{x: 0, y: -2}],
         [],
         Object.values(circuit.devices.mosfets),

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -2,13 +2,12 @@
 import { gndNodeId, vddNodeId, gndVoltage, vddVoltage } from '../constants'
 import { Circuit } from '../classes/circuit'
 import { Node } from '../classes/node'
-import { computed, Ref, ref } from 'vue'
+import { computed, ref } from 'vue'
 // import { ParasiticCapacitor } from '../classes/parasiticCapacitor'
 import { Schematic } from '../classes/schematic'
 import { Mosfet } from '../classes/mosfet'
 import { VoltageSource } from '../classes/voltageSource'
-import { between, foldl } from '../functions/extraMath'
-import { TransformationMatrix } from '../classes/transformationMatrix'
+import { between } from '../functions/extraMath'
 import { TectonicLine, TectonicPlate, TectonicPoint } from '../classes/tectonicPlate'
 import { getPointAlongPath } from '../functions/drawFuncs'
 import { GndSymbol } from '../classes/powerSymbols'
@@ -24,11 +23,7 @@ const usePmosSingle = () => {
     circuit.nodes = {
         [gndNodeId]: ref(new Node(gndVoltage, true)),
         [vddNodeId]: ref(new Node(vddVoltage, true)),
-        "M1_drain": ref(new Node(5, false,
-            [
-                new TectonicLine(circuit.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
-            ]
-        )),
+        "M1_drain": ref(new Node(5, false)),
         "M1_gate": ref(new Node(1, false)),
     }
 
@@ -79,19 +74,20 @@ const usePmosSingle = () => {
         circuit.transformations,
         [new GndSymbol(circuit.transformations, {x: 0, y: 8})],
         [new VddSymbol(tectonicPlate.transformations, circuit.devices.mosfets["M1"].getAnchorPoint("Vd"))],
-        // [{x: 0, y: -2}],
         [],
         Object.values(circuit.devices.mosfets),
-        Object.values(circuit.nodes)
+        Object.values(circuit.nodes),
+        [
+            {
+                node: circuit.nodes["M1_drain"],
+                lines: [
+                    new TectonicLine(circuit.transformations, {x: 0, y: 2}, circuit.transformations, {x: 0, y: 4}),
+                ],
+                voltageDisplayLabel: "Drain",
+                voltageDisplayLocations: [new TectonicPoint(circuit.transformations, {x: 0, y: 3})]
+            }
+        ]
     )
-
-    //////////////////////////////
-    ///        FUNCTIONS       ///
-    //////////////////////////////
-
-    circuit.updateDevicePositions = (_circuit: Circuit) => {
-        tectonicPlate.moveTowardDesiredLocation()
-    }
 
     return circuit
 }

--- a/src/classes/angleSlider.ts
+++ b/src/classes/angleSlider.ts
@@ -28,8 +28,8 @@ export class AngleSlider extends CtxArtist{
     fromNode: Ref<Node>
     toNode: Ref<Node>
 
-    constructor(parentTransformationMatrix: TransformationMatrix, fromNode: Ref<Node>, toNode: Ref<Node>, centerX: number, centerY: number, radius: number, startAngle: number, endAngle: number, CCW: boolean, minValue: number, maxValue: number, name: string, visibility: Visibility, displayNegative: boolean = false) {
-        super(parentTransformationMatrix.translate({x: centerX, y: centerY}).rotate(startAngle).mirror(false, CCW))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], fromNode: Ref<Node>, toNode: Ref<Node>, centerX: number, centerY: number, radius: number, startAngle: number, endAngle: number, CCW: boolean, minValue: number, maxValue: number, name: string, visibility: Visibility, displayNegative: boolean = false) {
+        super(parentTransformations, (new TransformationMatrix()).translate({x: centerX, y: centerY}).rotate(startAngle).mirror(false, CCW))
 
         this.dragging = false
         this.preciseDragging = false

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -39,6 +39,10 @@ export class Circuit extends CtxArtist {
         }
         this.nodes = nodes
         this.textTransformationMatrix = textTransformationMatrix.translate(origin).scale(scale / schematicScale)
+
+        // set static transformation matrices for the circuit // must be applied during construction because it will be used immediately as other elements of the circuit are defined immediately after its definition
+        CtxArtist.circuitTransformationMatrix = this.transformationMatrix
+        CtxArtist.textTransformationMatrix = this.textTransformationMatrix
     }
 
     get allSliders(): AngleSlider[] {

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -70,9 +70,9 @@ export class Circuit extends CtxArtist {
                     slidersDragging = true
                 }
             })
-            if (!slidersDragging) {
+            // if (!slidersDragging) {
                 TectonicPlate.allTectonicPlates.forEach((tectonicPlate: TectonicPlate) => {tectonicPlate.moveTowardDesiredLocation()})
-            }
+            // }
         }
 
         this.schematic.draw(ctx)

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -10,6 +10,7 @@ import { Node } from "./node"
 import { canvasDpi, canvasSize, drawGrid, moveNodesInResponseToCircuitState, schematicScale } from "../constants"
 import { modulo } from "../functions/extraMath"
 import { drawCirclesFillSolid } from "../functions/drawFuncs"
+import { TectonicPlate } from "./tectonicPlate"
 
 export class Circuit extends CtxArtist {
     width: number
@@ -22,9 +23,8 @@ export class Circuit extends CtxArtist {
     }
     nodes: {[nodeId: string]: Ref<Node>} // a dictionary mapping the names of the nodes in the circuit with their voltages (in V)
     textTransformationMatrix: TransformationMatrix
-    updateDevicePositions: (circuit: Circuit) => void
 
-    constructor(origin: Point, width: number, height: number, schematic: Schematic = new Schematic([], [], [], [], [], []), mosfets: {[name: string]: Mosfet} = {}, voltageSources: {[name: string]: VoltageSource} = {}, nodes: {[nodeId: string]: Ref<Node>} = {}, textTransformationMatrix = new TransformationMatrix(), updateDevicePositions: () => void = () => {}) {
+    constructor(origin: Point, width: number, height: number, schematic: Schematic = new Schematic(), mosfets: {[name: string]: Mosfet} = {}, voltageSources: {[name: string]: VoltageSource} = {}, nodes: {[nodeId: string]: Ref<Node>} = {}, textTransformationMatrix = new TransformationMatrix()) {
         const scale = Math.min(canvasSize.x / width, canvasSize.y / height)
         const extraShift = {x: (canvasSize.x / scale - width) / 2, y: (canvasSize.y / scale - height) / 2}
         super([], (new TransformationMatrix()).scale(scale * canvasDpi).translate({x: -origin.x + width / 2, y: -origin.y + height / 2}).translate(extraShift))
@@ -39,7 +39,6 @@ export class Circuit extends CtxArtist {
         }
         this.nodes = nodes
         this.textTransformationMatrix = textTransformationMatrix.translate(origin).scale(scale / schematicScale)
-        this.updateDevicePositions = updateDevicePositions
     }
 
     get allSliders(): AngleSlider[] {
@@ -63,7 +62,7 @@ export class Circuit extends CtxArtist {
                 }
             })
             if (!slidersDragging) {
-                this.updateDevicePositions(this)
+                TectonicPlate.allTectonicPlates.forEach((tectonicPlate: TectonicPlate) => {tectonicPlate.moveTowardDesiredLocation()})
             }
         }
 
@@ -96,7 +95,6 @@ export class Circuit extends CtxArtist {
         CtxArtist.circuitTransformationMatrix.transformCanvas(ctx)
         const topLeftCornerOfCanvasInLocalReferenceFrame = CtxArtist.circuitTransformationMatrix.inverse().transformPoint({x: 0, y: 0})
         const bottomRightCornerOfCanvasInLocalReferenceFrame = CtxArtist.circuitTransformationMatrix.inverse().transformPoint(canvasSize)
-        console.log(topLeftCornerOfCanvasInLocalReferenceFrame.x, topLeftCornerOfCanvasInLocalReferenceFrame.y)
         for (let xPosition = Math.floor(topLeftCornerOfCanvasInLocalReferenceFrame.x); xPosition <= Math.ceil(bottomRightCornerOfCanvasInLocalReferenceFrame.x); xPosition += 1) {
             for (let yPosition = Math.floor(topLeftCornerOfCanvasInLocalReferenceFrame.y); yPosition <= Math.ceil(bottomRightCornerOfCanvasInLocalReferenceFrame.y); yPosition += 1) {
                 let dotRadius = 0.1

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -6,8 +6,6 @@ import { foldl } from "../functions/extraMath"
 
 export class CtxArtist {
     transformations: Ref<TransformationMatrix>[] = []
-    globalTransformationMatrix: TransformationMatrix = new TransformationMatrix()
-    originalLocalTransformationMatrix: TransformationMatrix
     anchorPoints: {[name: string]: Point} = {}
     _transformationMatrix: ComputedRef<TransformationMatrix>
 
@@ -20,7 +18,6 @@ export class CtxArtist {
         // if you change the last element of this.transformations[this.transformations.length - 1], it will propagate down to all children
         parentTransformations.forEach(transformation => {this.transformations.push(transformation)}) // make a shallow copy of the array
         this.transformations.push(ref(localTransformationMatrix) as Ref<TransformationMatrix>) // then append the local transformation matrix
-        this.originalLocalTransformationMatrix = localTransformationMatrix
         this._transformationMatrix = computed(() => { return foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(), this.transformations) })
 
         CtxArtist.allCtxArtists.push(this)

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -1,7 +1,7 @@
 import { Point } from "../types"
 import { TransformationMatrix } from "./transformationMatrix"
 import { GLOBAL_LINE_THICKNESS } from "../constants"
-import { ref, Ref } from "vue"
+import { computed, ComputedRef, ref, Ref } from "vue"
 import { foldl } from "../functions/extraMath"
 
 export class CtxArtist {
@@ -9,7 +9,7 @@ export class CtxArtist {
     globalTransformationMatrix: TransformationMatrix = new TransformationMatrix()
     originalLocalTransformationMatrix: TransformationMatrix
     anchorPoints: {[name: string]: Point} = {}
-    _transformationMatrix: Ref<TransformationMatrix>
+    _transformationMatrix: ComputedRef<TransformationMatrix>
 
     static textTransformationMatrix: TransformationMatrix = new TransformationMatrix()
     static circuitTransformationMatrix: TransformationMatrix = new TransformationMatrix()
@@ -20,7 +20,7 @@ export class CtxArtist {
         this.transformations.push(ref(localTransformationMatrix) as Ref<TransformationMatrix>) // then append the local transformation matrix
         // this.updateTransformationMatrix()
         this.originalLocalTransformationMatrix = localTransformationMatrix
-        this._transformationMatrix = ref(foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(), this.transformations)) as Ref<TransformationMatrix>
+        this._transformationMatrix = computed(() => { return foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(), this.transformations) })
 
         CtxArtist.allCtxArtists.push(this)
     }

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -32,7 +32,14 @@ export class CtxArtist {
     }
 
     getAnchorPoint(name: string): Point {
+        if (this.anchorPoints[name] == undefined) {
+            console.log("Cannot find anchor point", name, "on CtxArtist")
+        }
         return CtxArtist.circuitTransformationMatrix.inverse().multiply(this.transformationMatrix).transformPoint(this.anchorPoints[name])
+    }
+
+    getAnchorPointWithTransformations(name: string): [Ref<TransformationMatrix>[], Point] {
+        return [this.transformations.slice(0, -1), this.getAnchorPoint(name)]
     }
 
     moveTo(destination: Point) {

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -20,7 +20,6 @@ export class CtxArtist {
         // if you change the last element of this.transformations[this.transformations.length - 1], it will propagate down to all children
         parentTransformations.forEach(transformation => {this.transformations.push(transformation)}) // make a shallow copy of the array
         this.transformations.push(ref(localTransformationMatrix) as Ref<TransformationMatrix>) // then append the local transformation matrix
-        // this.updateTransformationMatrix()
         this.originalLocalTransformationMatrix = localTransformationMatrix
         this._transformationMatrix = computed(() => { return foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(), this.transformations) })
 
@@ -29,6 +28,10 @@ export class CtxArtist {
 
     get transformationMatrix(): TransformationMatrix {
         return this._transformationMatrix.value
+    }
+
+    get localTransformationMatrix(): TransformationMatrix {
+        return this.transformations[this.transformations.length - 1].value
     }
 
     getAnchorPoint(name: string): Point {

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -16,6 +16,8 @@ export class CtxArtist {
     static allCtxArtists: CtxArtist[] = []
 
     constructor (parentTransformations: Ref<TransformationMatrix>[] = [], localTransformationMatrix: TransformationMatrix = new TransformationMatrix()) {
+        // this.transformations: [ ref(topLevelTM), ref(circuitTM), ref(mosfetTM), ref(angleSliderTM), ref(thisTM) ]
+        // if you change the last element of this.transformations[this.transformations.length - 1], it will propagate down to all children
         parentTransformations.forEach(transformation => {this.transformations.push(transformation)}) // make a shallow copy of the array
         this.transformations.push(ref(localTransformationMatrix) as Ref<TransformationMatrix>) // then append the local transformation matrix
         // this.updateTransformationMatrix()
@@ -35,21 +37,7 @@ export class CtxArtist {
 
     moveTo(destination: Point) {
         this.transformations[this.transformations.length - 1].value.translation = destination
-        // CtxArtist.updateAllCtxArtistTransformationMatrices()
     }
-
-    // updateTransformationMatrix() {
-    //     this.globalTransformationMatrix = new TransformationMatrix()
-    //     this.transformations.forEach((transformation: Ref<TransformationMatrix>) => {
-    //         this.globalTransformationMatrix.multiply(transformation.value, true)
-    //     })
-    // }
-
-    // static updateAllCtxArtistTransformationMatrices() {
-    //     CtxArtist.allCtxArtists.forEach((artist: CtxArtist) => {
-    //         artist.updateTransformationMatrix()
-    //     })
-    // }
 
     get localLineThickness(): number {
         return this.getLocalLineThickness()

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -60,12 +60,15 @@ export class Mosfet extends CtxArtist{
             this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility)
 
             this.anchorPoints = {
-                "Vg": {x: 30, y: 0},
+                "Vg": {x: 60, y: 0},
                 "Vs": {x: 0, y: 60},
                 "Vd": {x: 0, y: -60},
                 "Vb": {x: 0, y: 0},
                 "Gnd": {x: 0, y: 90},
                 "Vdd": {x: 0, y: -90},
+                "Vg_mirror_gate": {x: 90, y: 0},
+                "Vg_mirror_corner": {x: 90, y: 90},
+                "Vg_mirror_drain": {x: 0, y: 90},
             }
         }
         else {
@@ -73,12 +76,15 @@ export class Mosfet extends CtxArtist{
             this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, -maxVds, 0, 'Vsd', vdsVisibility, true)
 
             this.anchorPoints = {
-                "Vg": {x: 30, y: 0},
+                "Vg": {x: 60, y: 0},
                 "Vs": {x: 0, y: -60},
                 "Vd": {x: 0, y: 60},
                 "Vb": {x: 0, y: 0},
                 "Gnd": {x: 0, y: 90},
                 "Vdd": {x: 0, y: -90},
+                "Vg_mirror_gate": {x: 90, y: 0},
+                "Vg_mirror_corner": {x: 90, y: 90},
+                "Vg_mirror_drain": {x: 0, y: 90},
             }
         }
     }

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -11,13 +11,14 @@ import { drawCirclesFillSolid, drawLinesFillSolid, drawLinesFillWithGradient, ma
 import { interpolateInferno } from "d3"
 import { Node } from "./node"
 import { CurrentDots } from "./currentDots"
+import { TectonicPoint } from "./tectonicPlate"
 
 export class Mosfet extends CtxArtist{
     mosfetType: 'nmos' | 'pmos'
     // mirror: boolean
     currentDots: CurrentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
     gradientSize: number = 100
-    schematicEffects: { [name: string]: {node: Ref<Node>, effect: SchematicEffect} }
+    schematicEffects: {[name: string]: SchematicEffect}
     vgs: AngleSlider
     vds: AngleSlider
     Vg: Ref<Node>
@@ -32,25 +33,21 @@ export class Mosfet extends CtxArtist{
         this.schematicEffects = {
             "gate": {
                 node: Vg,
-                effect: {
-                    origin: {
-                        x: 30,
-                        y: 0,
-                    },
-                    color: 'red',
-                    gradientSize: 2,
-                }
+                origin: new TectonicPoint(this.transformations, {
+                    x: 30,
+                    y: 0,
+                }),
+                color: 'red',
+                gradientSize: 2,
             },
             "saturation": {
                 node: Vd,
-                effect: {
-                    origin: {
-                        x: 0,
-                        y: 30 * (mosfetType == 'nmos' ? -1 : 1),
-                    },
-                    color: 'red',
-                    gradientSize: 100,
-                }
+                origin: new TectonicPoint(this.transformations, {
+                    x: 0,
+                    y: 30 * (mosfetType == 'nmos' ? -1 : 1),
+                }),
+                color: 'red',
+                gradientSize: 100,
             },
         },
         this.Vg = Vg
@@ -109,10 +106,10 @@ export class Mosfet extends CtxArtist{
         drawCirclesFillSolid(ctx, gateCircles, this.localLineThickness, gateColor)
         drawLinesFillWithGradient(ctx, bodyLines, this.localLineThickness, gradient)
 
-        this.schematicEffects["saturation"].effect.gradientSize = this.gradientSize / 30 * 3.5
-        this.schematicEffects["saturation"].effect.color = 'rgba(200, 200, 200, 1)'
-        this.schematicEffects["gate"].effect.gradientSize = forwardCurrentScaled * 3.5
-        this.schematicEffects["gate"].effect.color = gateColor
+        this.schematicEffects["saturation"].gradientSize = this.gradientSize / 30 * 3.5
+        this.schematicEffects["saturation"].color = 'rgba(200, 200, 200, 1)'
+        this.schematicEffects["gate"].gradientSize = forwardCurrentScaled * 3.5
+        this.schematicEffects["gate"].color = gateColor
 
         this.currentDots.draw(ctx)
 

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -58,16 +58,24 @@ export class Mosfet extends CtxArtist{
         if (this.mosfetType == 'nmos') {
             this.vgs = new AngleSlider(this.transformations, Vs, Vg, 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility)
             this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility)
+
+            this.anchorPoints = {
+                "Vg": {x: 30, y: 0},
+                "Vs": {x: 0, y: 60},
+                "Vd": {x: 0, y: -60},
+                "Vb": {x: 0, y: 0},
+            }
         }
         else {
             this.vgs = new AngleSlider(this.transformations, Vs, Vg, 10, -10, 60, toRadians(-5), toRadians(70), true, -maxVgs, 0, 'Vsg', vgsVisibility, true)
             this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, -maxVds, 0, 'Vsd', vdsVisibility, true)
-        }
-        this.anchorPoints = {
-            "Vg": {x: 30, y: 0},
-            "Vs": {x: 0, y: 60},
-            "Vd": {x: 0, y: -60},
-            "Vb": {x: 0, y: 0},
+
+            this.anchorPoints = {
+                "Vg": {x: 30, y: 0},
+                "Vs": {x: 0, y: -60},
+                "Vd": {x: 0, y: 60},
+                "Vb": {x: 0, y: 0},
+            }
         }
     }
 

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -67,8 +67,8 @@ export class Mosfet extends CtxArtist{
                 "Gnd": {x: 0, y: 90},
                 "Vdd": {x: 0, y: -90},
                 "Vg_mirror_gate": {x: 90, y: 0},
-                "Vg_mirror_corner": {x: 90, y: 90},
-                "Vg_mirror_drain": {x: 0, y: 90},
+                "Vg_mirror_corner": {x: 90, y: -90},
+                "Vg_mirror_drain": {x: 0, y: -90},
             }
         }
         else {

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -64,6 +64,8 @@ export class Mosfet extends CtxArtist{
                 "Vs": {x: 0, y: 60},
                 "Vd": {x: 0, y: -60},
                 "Vb": {x: 0, y: 0},
+                "Gnd": {x: 0, y: 90},
+                "Vdd": {x: 0, y: -90},
             }
         }
         else {
@@ -75,6 +77,8 @@ export class Mosfet extends CtxArtist{
                 "Vs": {x: 0, y: -60},
                 "Vd": {x: 0, y: 60},
                 "Vb": {x: 0, y: 0},
+                "Gnd": {x: 0, y: 90},
+                "Vdd": {x: 0, y: -90},
             }
         }
     }

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -69,6 +69,8 @@ export class Mosfet extends CtxArtist{
                 "Vg_mirror_gate": {x: 90, y: 0},
                 "Vg_mirror_corner": {x: 90, y: -90},
                 "Vg_mirror_drain": {x: 0, y: -90},
+                "Vg_drive_gate": {x: 120, y: 0},
+                "Vg_drive_Vsource": {x: 120, y: 90},
             }
         }
         else {
@@ -85,6 +87,8 @@ export class Mosfet extends CtxArtist{
                 "Vg_mirror_gate": {x: 90, y: 0},
                 "Vg_mirror_corner": {x: 90, y: 90},
                 "Vg_mirror_drain": {x: 0, y: 90},
+                "Vg_drive_gate": {x: 120, y: 0},
+                "Vg_drive_Vsource": {x: 120, y: 90},
             }
         }
     }

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -14,9 +14,9 @@ import { CurrentDots } from "./currentDots"
 
 export class Mosfet extends CtxArtist{
     mosfetType: 'nmos' | 'pmos'
-    mirror: boolean // obsolete
-    currentDots: CurrentDots
-    gradientSize: number
+    // mirror: boolean
+    currentDots: CurrentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
+    gradientSize: number = 100
     schematicEffects: {[name: string]: SchematicEffect}
     vgs: AngleSlider
     vds: AngleSlider
@@ -24,15 +24,11 @@ export class Mosfet extends CtxArtist{
     Vs: Ref<Node>
     Vd: Ref<Node>
     Vb: Ref<Node>
-    // current: number // in Amps
-    // saturationLevel: number // as a fraction of total saturation (0 to 1)
-    // forwardCurrent: number // in Amps
 
-    constructor(parentTransformationMatrix: TransformationMatrix, mosfetType: 'nmos' | 'pmos', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, maxVgs: number = 3, maxVds: number = 5, mirror: boolean = false, vgsVisibility: Visibility = Visibility.Visible, vdsVisibility: Visibility = Visibility.Visible) {
-        super(parentTransformationMatrix.translate({x: originX, y: originY}).scale(1/30).mirror(mirror, false))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, maxVgs: number = 3, maxVds: number = 5, mirror: boolean = false, vgsVisibility: Visibility = Visibility.Visible, vdsVisibility: Visibility = Visibility.Visible) {
+        super(parentTransformations, (new TransformationMatrix()).translate({x: originX, y: originY}).scale(1/30).mirror(mirror, false))
         this.mosfetType = mosfetType
-        this.mirror = mirror
-        this.gradientSize = 100
+        // this.mirror = mirror
         this.schematicEffects = {
             "gate": {
                 node: Vg,
@@ -53,22 +49,24 @@ export class Mosfet extends CtxArtist{
                 gradientSize: 100,
             },
         },
-        this.currentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
         this.Vg = Vg
         this.Vs = Vs
         this.Vd = Vd
         this.Vb = Vb
-        // this.current = this.getMosfetCurrent()
-        // this.saturationLevel = this.getMosfetSaturationLevel()
-        // this.forwardCurrent = this.getMosfetForwardCurrent()
 
         if (this.mosfetType == 'nmos') {
-            this.vgs = new AngleSlider(this.transformationMatrix, Vs, Vg, 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility)
-            this.vds = new AngleSlider(this.transformationMatrix, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility)
+            this.vgs = new AngleSlider(this.transformations, Vs, Vg, 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility)
+            this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility)
         }
         else {
-            this.vgs = new AngleSlider(this.transformationMatrix, Vs, Vg, 10, -10, 60, toRadians(-5), toRadians(70), true, -maxVgs, 0, 'Vsg', vgsVisibility, true)
-            this.vds = new AngleSlider(this.transformationMatrix, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, -maxVds, 0, 'Vsd', vdsVisibility, true)
+            this.vgs = new AngleSlider(this.transformations, Vs, Vg, 10, -10, 60, toRadians(-5), toRadians(70), true, -maxVgs, 0, 'Vsg', vgsVisibility, true)
+            this.vds = new AngleSlider(this.transformations, Vs, Vd, 30, 0, 75, toRadians(140), toRadians(80), false, -maxVds, 0, 'Vsd', vdsVisibility, true)
+        }
+        this.anchorPoints = {
+            "Vg": {x: 30, y: 0},
+            "Vs": {x: 0, y: 60},
+            "Vd": {x: 0, y: -60},
+            "Vb": {x: 0, y: 0},
         }
     }
 

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -33,8 +33,8 @@ export class Mosfet extends CtxArtist{
             "gate": {
                 node: Vg,
                 origin: {
-                x: 30,
-                y: 0,
+                    x: 30,
+                    y: 0,
                 },
                 color: 'red',
                 gradientSize: 2,
@@ -42,8 +42,8 @@ export class Mosfet extends CtxArtist{
             "saturation": {
                 node: Vd,
                 origin: {
-                x: 0,
-                y: 30 * (mosfetType == 'nmos' ? -1 : 1),
+                    x: 0,
+                    y: 30 * (mosfetType == 'nmos' ? -1 : 1),
                 },
                 color: 'red',
                 gradientSize: 100,

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -17,7 +17,7 @@ export class Mosfet extends CtxArtist{
     // mirror: boolean
     currentDots: CurrentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
     gradientSize: number = 100
-    schematicEffects: {[name: string]: SchematicEffect}
+    schematicEffects: { [name: string]: {node: Ref<Node>, effect: SchematicEffect} }
     vgs: AngleSlider
     vds: AngleSlider
     Vg: Ref<Node>
@@ -32,21 +32,25 @@ export class Mosfet extends CtxArtist{
         this.schematicEffects = {
             "gate": {
                 node: Vg,
-                origin: {
-                    x: 30,
-                    y: 0,
-                },
-                color: 'red',
-                gradientSize: 2,
+                effect: {
+                    origin: {
+                        x: 30,
+                        y: 0,
+                    },
+                    color: 'red',
+                    gradientSize: 2,
+                }
             },
             "saturation": {
                 node: Vd,
-                origin: {
-                    x: 0,
-                    y: 30 * (mosfetType == 'nmos' ? -1 : 1),
-                },
-                color: 'red',
-                gradientSize: 100,
+                effect: {
+                    origin: {
+                        x: 0,
+                        y: 30 * (mosfetType == 'nmos' ? -1 : 1),
+                    },
+                    color: 'red',
+                    gradientSize: 100,
+                }
             },
         },
         this.Vg = Vg
@@ -105,10 +109,10 @@ export class Mosfet extends CtxArtist{
         drawCirclesFillSolid(ctx, gateCircles, this.localLineThickness, gateColor)
         drawLinesFillWithGradient(ctx, bodyLines, this.localLineThickness, gradient)
 
-        this.schematicEffects["saturation"].gradientSize = this.gradientSize / 30 * 3.5
-        this.schematicEffects["saturation"].color = 'rgba(200, 200, 200, 1)'
-        this.schematicEffects["gate"].gradientSize = forwardCurrentScaled * 3.5
-        this.schematicEffects["gate"].color = gateColor
+        this.schematicEffects["saturation"].effect.gradientSize = this.gradientSize / 30 * 3.5
+        this.schematicEffects["saturation"].effect.color = 'rgba(200, 200, 200, 1)'
+        this.schematicEffects["gate"].effect.gradientSize = forwardCurrentScaled * 3.5
+        this.schematicEffects["gate"].effect.color = gateColor
 
         this.currentDots.draw(ctx)
 

--- a/src/classes/node.ts
+++ b/src/classes/node.ts
@@ -1,8 +1,8 @@
-import { Line, Point } from "../types"
+import { Line, Point, SchematicEffect } from "../types"
 import { Queue } from "./queue"
 import { defaultNodeCapacitance, powerSupplyCapacitance } from "../constants"
-import { TectonicLine } from "./tectonicPlate"
-import { markRaw } from "vue"
+// import { TectonicLine } from "./tectonicPlate"
+// import { markRaw } from "vue"
 // import { ref, Ref } from "vue"
 
 export class Node {
@@ -12,11 +12,12 @@ export class Node {
     originalCapacitance: number // in
     fixed: boolean // GND and VDD nodes are fixed, as are nodes that are being dragged
     historicVoltages: Queue<number>
-    _lines: TectonicLine[]
-    voltageDisplayLabel: string
-    voltageDisplayLocations: Point[]
+    // _lines: TectonicLine[]
+    // voltageDisplayLabel: string
+    // voltageDisplayLocations: Point[]
+    schematicEffects: SchematicEffect[] = []
 
-    constructor(initialVoltage: number, isPowerSupply: boolean, lines: TectonicLine[] = [], voltageDisplayLabel: string = "", voltageDisplayLocations: Point[] = []) {
+    constructor(initialVoltage: number, isPowerSupply: boolean) {
         const historicVoltages: Queue<number> = new Queue<number>()
         historicVoltages.fill(0, 10)
         const capacitance = isPowerSupply ? powerSupplyCapacitance : defaultNodeCapacitance // in Farads
@@ -27,12 +28,12 @@ export class Node {
         this.originalCapacitance = capacitance
         this.fixed = isPowerSupply ? true : false // GND and VDD nodes are fixed, as are nodes that are being dragged
         this.historicVoltages = historicVoltages
-        this._lines = markRaw(lines) // https://stackoverflow.com/a/73940781
-        this.voltageDisplayLabel = voltageDisplayLabel
-        this.voltageDisplayLocations = voltageDisplayLocations
+        // this._lines = markRaw(lines) // https://stackoverflow.com/a/73940781
+        // this.voltageDisplayLabel = voltageDisplayLabel
+        // this.voltageDisplayLocations = voltageDisplayLocations
     }
 
-    get lines(): Line[] {
-        return this._lines.map((line: TectonicLine) => line.toLine())
-    }
+    // get lines(): Line[] {
+    //     return this._lines.map((line: TectonicLine) => line.toLine())
+    // }
 }

--- a/src/classes/node.ts
+++ b/src/classes/node.ts
@@ -1,9 +1,6 @@
-import { Line, Point, SchematicEffect } from "../types"
+import { SchematicEffect } from "../types"
 import { Queue } from "./queue"
 import { defaultNodeCapacitance, powerSupplyCapacitance } from "../constants"
-// import { TectonicLine } from "./tectonicPlate"
-// import { markRaw } from "vue"
-// import { ref, Ref } from "vue"
 
 export class Node {
     voltage: number // in Volts
@@ -12,9 +9,6 @@ export class Node {
     originalCapacitance: number // in
     fixed: boolean // GND and VDD nodes are fixed, as are nodes that are being dragged
     historicVoltages: Queue<number>
-    // _lines: TectonicLine[]
-    // voltageDisplayLabel: string
-    // voltageDisplayLocations: Point[]
     schematicEffects: SchematicEffect[] = []
 
     constructor(initialVoltage: number, isPowerSupply: boolean) {
@@ -28,12 +22,5 @@ export class Node {
         this.originalCapacitance = capacitance
         this.fixed = isPowerSupply ? true : false // GND and VDD nodes are fixed, as are nodes that are being dragged
         this.historicVoltages = historicVoltages
-        // this._lines = markRaw(lines) // https://stackoverflow.com/a/73940781
-        // this.voltageDisplayLabel = voltageDisplayLabel
-        // this.voltageDisplayLocations = voltageDisplayLocations
     }
-
-    // get lines(): Line[] {
-    //     return this._lines.map((line: TectonicLine) => line.toLine())
-    // }
 }

--- a/src/classes/node.ts
+++ b/src/classes/node.ts
@@ -1,4 +1,4 @@
-import { SchematicEffect } from "../types"
+import { FlattenedSchematicEffect } from "../types"
 import { Queue } from "./queue"
 import { defaultNodeCapacitance, powerSupplyCapacitance } from "../constants"
 
@@ -9,7 +9,7 @@ export class Node {
     originalCapacitance: number // in
     fixed: boolean // GND and VDD nodes are fixed, as are nodes that are being dragged
     historicVoltages: Queue<number>
-    schematicEffects: SchematicEffect[] = []
+    schematicEffects: FlattenedSchematicEffect[] = []
 
     constructor(initialVoltage: number, isPowerSupply: boolean) {
         const historicVoltages: Queue<number> = new Queue<number>()

--- a/src/classes/node.ts
+++ b/src/classes/node.ts
@@ -1,7 +1,8 @@
 import { Line, Point } from "../types"
 import { Queue } from "./queue"
 import { defaultNodeCapacitance, powerSupplyCapacitance } from "../constants"
-import { ref, Ref } from "vue"
+import { TectonicLine } from "./tectonicPlate"
+// import { ref, Ref } from "vue"
 
 export class Node {
     voltage: number // in Volts
@@ -10,11 +11,11 @@ export class Node {
     originalCapacitance: number // in
     fixed: boolean // GND and VDD nodes are fixed, as are nodes that are being dragged
     historicVoltages: Queue<number>
-    lines: Line[]
+    _lines: TectonicLine[]
     voltageDisplayLabel: string
     voltageDisplayLocations: Point[]
 
-    constructor(initialVoltage: number, isPowerSupply: boolean, lines: Line[] = [], voltageDisplayLabel: string = "", voltageDisplayLocations: Point[] = []) {
+    constructor(initialVoltage: number, isPowerSupply: boolean, lines: TectonicLine[] = [], voltageDisplayLabel: string = "", voltageDisplayLocations: Point[] = []) {
         const historicVoltages: Queue<number> = new Queue<number>()
         historicVoltages.fill(0, 10)
         const capacitance = isPowerSupply ? powerSupplyCapacitance : defaultNodeCapacitance // in Farads
@@ -25,12 +26,12 @@ export class Node {
         this.originalCapacitance = capacitance
         this.fixed = isPowerSupply ? true : false // GND and VDD nodes are fixed, as are nodes that are being dragged
         this.historicVoltages = historicVoltages
-        this.lines = lines
+        this._lines = lines
         this.voltageDisplayLabel = voltageDisplayLabel
         this.voltageDisplayLocations = voltageDisplayLocations
     }
 
-    toRef(): Ref<Node> {
-        return ref(this)
+    get lines(): Line[] {
+        return this._lines.map((line: TectonicLine) => line.toLine())
     }
 }

--- a/src/classes/node.ts
+++ b/src/classes/node.ts
@@ -2,6 +2,7 @@ import { Line, Point } from "../types"
 import { Queue } from "./queue"
 import { defaultNodeCapacitance, powerSupplyCapacitance } from "../constants"
 import { TectonicLine } from "./tectonicPlate"
+import { markRaw } from "vue"
 // import { ref, Ref } from "vue"
 
 export class Node {
@@ -26,7 +27,7 @@ export class Node {
         this.originalCapacitance = capacitance
         this.fixed = isPowerSupply ? true : false // GND and VDD nodes are fixed, as are nodes that are being dragged
         this.historicVoltages = historicVoltages
-        this._lines = lines
+        this._lines = markRaw(lines) // https://stackoverflow.com/a/73940781
         this.voltageDisplayLabel = voltageDisplayLabel
         this.voltageDisplayLocations = voltageDisplayLocations
     }

--- a/src/classes/parasiticCapacitor.ts
+++ b/src/classes/parasiticCapacitor.ts
@@ -3,15 +3,16 @@ import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { Ref } from 'vue'
 import { drawLinesFillSolid } from "../functions/drawFuncs"
-import { Schematic } from "./schematic"
 import { toSiPrefix } from "../functions/toSiPrefix"
 import { Node } from "./node"
 import { CurrentDots } from "./currentDots"
+import { GndSymbol } from "./powerSymbols"
 
 export class ParasiticCapacitor extends CtxArtist{
     node: Ref<Node>
     extraNodeLines: Line[]
     currentDots: CurrentDots
+    gndSymbol: GndSymbol
     static displayCurrent: boolean = false
 
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], node: Ref<Node>, center: Point, extraNodeLines: Line[]) {
@@ -19,6 +20,7 @@ export class ParasiticCapacitor extends CtxArtist{
         this.node = node
         this.extraNodeLines = extraNodeLines
         this.currentDots = new CurrentDots([{start: {x: 10, y: -60}, end: {x: 10, y: 60}}])
+        this.gndSymbol = new GndSymbol(this.transformations, {x: 0, y: 30})
     }
 
     draw(ctx: CanvasRenderingContext2D) {
@@ -36,8 +38,10 @@ export class ParasiticCapacitor extends CtxArtist{
         drawLinesFillSolid(ctx, capacitorLines, this.localLineThickness, 'black')
         drawLinesFillSolid(ctx, extraNodeLines, this.localLineThickness, 'black')
         ctx.clearRect(-30 - this.localLineThickness, -airGapSize + this.localLineThickness / 2, 60 + 2 * this.localLineThickness, 2 * airGapSize - 2 * this.localLineThickness / 2)
-        Schematic.drawGnd(ctx, {x: 0, y: 50}, this.localLineThickness, 30)
 
+        this.gndSymbol.draw(ctx)
+
+        this.transformationMatrix.scale(0.5).transformCanvas(ctx)
         this.currentDots.draw(ctx)
 
         if (ParasiticCapacitor.displayCurrent) {

--- a/src/classes/parasiticCapacitor.ts
+++ b/src/classes/parasiticCapacitor.ts
@@ -14,8 +14,8 @@ export class ParasiticCapacitor extends CtxArtist{
     currentDots: CurrentDots
     static displayCurrent: boolean = false
 
-    constructor(parentTransformationMatrix: TransformationMatrix, node: Ref<Node>, center: Point, extraNodeLines: Line[]) {
-        super(parentTransformationMatrix.translate(center).scale(1/30))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], node: Ref<Node>, center: Point, extraNodeLines: Line[]) {
+        super(parentTransformations, (new TransformationMatrix()).translate(center).scale(1/30))
         this.node = node
         this.extraNodeLines = extraNodeLines
         this.currentDots = new CurrentDots([{start: {x: 10, y: -60}, end: {x: 10, y: 60}}])

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -31,6 +31,7 @@ export class VddSymbol extends CtxArtist{
     }
 
     draw(ctx: CanvasRenderingContext2D) {
+        console.log(this.transformationMatrix.translation)
         this.transformationMatrix.transformCanvas(ctx)
         const symbolSize = 0.8
 

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -21,7 +21,6 @@ export class GndSymbol extends CtxArtist{
         ctx.lineTo(-symbolSize / 2, 0)
         ctx.lineTo(0, 0)
         ctx.stroke()
-
     }
 }
 
@@ -31,7 +30,6 @@ export class VddSymbol extends CtxArtist{
     }
 
     draw(ctx: CanvasRenderingContext2D) {
-        console.log(this.transformationMatrix.translation)
         this.transformationMatrix.transformCanvas(ctx)
         const symbolSize = 0.8
 

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -1,0 +1,44 @@
+import { Point } from "../types"
+import { CtxArtist } from "./ctxArtist"
+import { TransformationMatrix } from "./transformationMatrix"
+import { Ref } from "vue"
+
+export class GndSymbol extends CtxArtist{
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point) {
+        super(parentTransformations, new TransformationMatrix().translate(origin))
+    }
+
+    draw(ctx: CanvasRenderingContext2D) {
+        this.transformationMatrix.transformCanvas(ctx)
+        const symbolSize = 0.8
+
+        ctx.strokeStyle = 'black'
+        ctx.lineWidth = this.localLineThickness
+        ctx.beginPath()
+        ctx.moveTo(0, 0)
+        ctx.lineTo(symbolSize / 2, 0)
+        ctx.lineTo(0, symbolSize / 2)
+        ctx.lineTo(-symbolSize / 2, 0)
+        ctx.lineTo(0, 0)
+        ctx.stroke()
+
+    }
+}
+
+export class VddSymbol extends CtxArtist{
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point) {
+        super(parentTransformations, new TransformationMatrix().translate(origin))
+    }
+
+    draw(ctx: CanvasRenderingContext2D) {
+        this.transformationMatrix.transformCanvas(ctx)
+        const symbolSize = 0.8
+
+        ctx.strokeStyle = 'black'
+        ctx.lineWidth = this.localLineThickness
+        ctx.beginPath()
+        ctx.moveTo(symbolSize / 2, 0)
+        ctx.lineTo(-symbolSize / 2, 0)
+        ctx.stroke()
+    }
+}

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -15,8 +15,8 @@ export class Schematic extends CtxArtist{
     mosfets: Mosfet[]
     nodes: Ref<Node>[]
 
-    constructor(parentTransformationMatrix: TransformationMatrix, gndLocations: Point[], vddLocations: Point[], parasiticCapacitors: ParasiticCapacitor[], mosfets: Mosfet[], nodes: Ref<Node>[]) {
-        super(parentTransformationMatrix)
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], gndLocations: Point[], vddLocations: Point[], parasiticCapacitors: ParasiticCapacitor[], mosfets: Mosfet[], nodes: Ref<Node>[]) {
+        super(parentTransformations, new TransformationMatrix())
         this.vddLocations = vddLocations
         this.gndLocations = gndLocations
         this.parasiticCapacitors = parasiticCapacitors

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -1,4 +1,4 @@
-import { Point, SchematicEffect, Wire } from "../types"
+import { FlattenedSchematicEffect, Point, SchematicEffect, Wire } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { ParasiticCapacitor } from "./parasiticCapacitor"
@@ -52,8 +52,9 @@ export class Schematic extends CtxArtist{
 
         // add gradient regions from each of the mosfets
         this.mosfets.forEach((mosfet: Mosfet) => {
-            Object.values(mosfet.schematicEffects).forEach((schematicEffect: {node: Ref<Node>, effect: SchematicEffect}) => {
-                schematicEffect.node.value.schematicEffects.push(schematicEffect.effect)
+            Object.values(mosfet.schematicEffects).forEach((schematicEffect: SchematicEffect) => {
+                const flattenedSchematicEffect: FlattenedSchematicEffect = Schematic.flattenSchematicEffect(schematicEffect)
+                schematicEffect.node.value.schematicEffects.push(flattenedSchematicEffect)
             })
         })
 
@@ -62,7 +63,7 @@ export class Schematic extends CtxArtist{
             drawLinesFillSolid(ctx, wire.lines.map((line: TectonicLine) => line.toLine()), this.localLineThickness, 'black')
 
             // then draw the gradient regions
-            wire.node.value.schematicEffects.forEach((schematicEffect: SchematicEffect) => {
+            wire.node.value.schematicEffects.forEach((schematicEffect: FlattenedSchematicEffect) => {
                 const gradientOrigin: Point = schematicEffect.origin // this.transformationMatrix.inverse().multiply(mosfet.transformationMatrix).transformPoint(schematicEffect.origin)
                 const gradient = makeStandardGradient(ctx, gradientOrigin, schematicEffect.gradientSize, schematicEffect.color)
 
@@ -76,13 +77,14 @@ export class Schematic extends CtxArtist{
                 this.fillTextGlobalReferenceFrame(ctx, labelLocation.toPoint(), wire.voltageDisplayLabel + " = " + toSiPrefix(wire.node.value.voltage, "V"), false)
             })
         })
+
         // this.nodes.forEach((node: Ref<Node>) => {
-        //     drawLinesFillSolid(ctx, node.value.lines, this.localLineThickness, 'black')
+            //     drawLinesFillSolid(ctx, node.value.lines, this.localLineThickness, 'black')
         // })
 
         // add gradient regions from each of the mosfets
         // this.mosfets.forEach((mosfet: Mosfet) => {
-        //     Object.values(mosfet.schematicEffects).forEach((schematicEffect: SchematicEffect) => {
+            //     Object.values(mosfet.schematicEffects).forEach((schematicEffect: SchematicEffect) => {
         //         const gradientOrigin: Point = this.transformationMatrix.inverse().multiply(mosfet.transformationMatrix).transformPoint(schematicEffect.origin)
         //         const gradient = makeStandardGradient(ctx, gradientOrigin, schematicEffect.gradientSize, schematicEffect.color)
 
@@ -92,11 +94,19 @@ export class Schematic extends CtxArtist{
 
         // // draw node voltage labels
         // this.nodes.forEach((node: Ref<Node>) => {
-        //     node.value.voltageDisplayLocations.forEach((labelLocation: Point) => {
+            //     node.value.voltageDisplayLocations.forEach((labelLocation: Point) => {
         //         ctx.fillStyle = 'black'
         //         ctx.font = '18px sans-serif'
         //         this.fillTextGlobalReferenceFrame(ctx, labelLocation, node.value.voltageDisplayLabel + " = " + toSiPrefix(node.value.voltage, "V"), false)
         //     })
         // })
+    }
+
+    static flattenSchematicEffect(schematicEffect: SchematicEffect): FlattenedSchematicEffect {
+        return {
+            origin: schematicEffect.origin.toPoint(),
+            color: schematicEffect.color,
+            gradientSize: schematicEffect.gradientSize,
+        }
     }
 }

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -7,18 +7,19 @@ import { drawLinesFillSolid, drawLinesFillWithGradient, makeStandardGradient } f
 import { Mosfet } from "./mosfet"
 import { Node } from "./node"
 import { toSiPrefix } from "../functions/toSiPrefix"
+import { GndSymbol, VddSymbol } from "./powerSymbols"
 
 export class Schematic extends CtxArtist{
-    vddLocations: Point[] // a list of locations to draw vdd symbols
-    gndLocations: Point[] // a list of locations to draw gnd symbols
+    gndSymbols: GndSymbol[] // a list of locations to draw gnd symbols
+    vddSymbols: VddSymbol[] // a list of locations to draw vdd symbols
     parasiticCapacitors: ParasiticCapacitor[]
     mosfets: Mosfet[]
     nodes: Ref<Node>[]
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], gndLocations: Point[], vddLocations: Point[], parasiticCapacitors: ParasiticCapacitor[], mosfets: Mosfet[], nodes: Ref<Node>[]) {
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], gndSymbols: GndSymbol[], vddSymbols: VddSymbol[], parasiticCapacitors: ParasiticCapacitor[], mosfets: Mosfet[], nodes: Ref<Node>[]) {
         super(parentTransformations, new TransformationMatrix())
-        this.vddLocations = vddLocations
-        this.gndLocations = gndLocations
+        this.gndSymbols = gndSymbols
+        this.vddSymbols = vddSymbols
         this.parasiticCapacitors = parasiticCapacitors
         this.mosfets = mosfets
         this.nodes = nodes
@@ -28,11 +29,11 @@ export class Schematic extends CtxArtist{
         this.transformationMatrix.transformCanvas(ctx)
 
         // draw vdd and gnd symbols
-        this.gndLocations.forEach((gndLocation) => {
-            Schematic.drawGnd(ctx, gndLocation, this.localLineThickness, 0.8)
+        this.gndSymbols.forEach((symbol) => {
+            symbol.draw(ctx)
         })
-        this.vddLocations.forEach((vddLocation) => {
-            Schematic.drawVdd(ctx, vddLocation, this.localLineThickness, 0.8)
+        this.vddSymbols.forEach((symbol) => {
+            symbol.draw(ctx)
         })
         this.parasiticCapacitors.forEach((capacitor) => {
             capacitor.draw(ctx)
@@ -63,26 +64,5 @@ export class Schematic extends CtxArtist{
                 this.fillTextGlobalReferenceFrame(ctx, labelLocation, node.value.voltageDisplayLabel + " = " + toSiPrefix(node.value.voltage, "V"), false)
             })
         })
-    }
-
-    static drawGnd(ctx: CanvasRenderingContext2D, origin: Point, lineThickness: number, symbolSize: number) {
-        ctx.strokeStyle = 'black'
-        ctx.lineWidth = lineThickness
-        ctx.beginPath()
-        ctx.moveTo(origin.x, origin.y)
-        ctx.lineTo(origin.x + symbolSize / 2, origin.y)
-        ctx.lineTo(origin.x, origin.y + symbolSize / 2)
-        ctx.lineTo(origin.x - symbolSize / 2, origin.y)
-        ctx.lineTo(origin.x, origin.y)
-        ctx.stroke()
-    }
-
-    static drawVdd(ctx: CanvasRenderingContext2D, origin: Point, lineThickness: number, symbolSize: number) {
-        ctx.strokeStyle = 'black'
-        ctx.lineWidth = lineThickness
-        ctx.beginPath()
-        ctx.moveTo(origin.x - symbolSize / 2, origin.y)
-        ctx.lineTo(origin.x + symbolSize / 2, origin.y)
-        ctx.stroke()
     }
 }

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -1,0 +1,31 @@
+import { Line, Point } from "../types"
+import { CtxArtist } from "./ctxArtist"
+import { TransformationMatrix } from "./transformationMatrix"
+import { computed, ComputedRef, Ref } from 'vue'
+import { getLineLength, getPointAlongLine } from "../functions/drawFuncs"
+
+export class TectonicPlate extends CtxArtist{
+    currentLocation: Point = {x: 0, y: 0}
+    desiredLocation: ComputedRef<Point>
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], desiredLocation: ComputedRef<Point> = computed(() => {return {x: 0, y: 0}})) {
+        super(parentTransformations, new TransformationMatrix())
+        this.desiredLocation = desiredLocation
+    }
+
+    moveTowardDesiredLocation() {
+        const currentLocation = this.currentLocation
+        const desiredLocation = this.desiredLocation.value
+        console.log("currentLocation: ", currentLocation, "desiredLocation", desiredLocation)
+        const lineToTravel: Line = {start: currentLocation, end: desiredLocation}
+        console.log(getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)))
+
+        let newLocation: Point = {x: 0, y: 0}
+        if (getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)) < 0.5) {
+            newLocation = desiredLocation
+        } else {
+            newLocation = getPointAlongLine(lineToTravel, 0.3)
+        }
+        this.moveTo(newLocation)
+        this.currentLocation = newLocation
+    }
+}

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -37,4 +37,22 @@ export class TectonicPoint extends CtxArtist {
         super(parentTransformations, new TransformationMatrix())
         this.point = point
     }
+
+    toPoint(): Point {
+        return CtxArtist.circuitTransformationMatrix.inverse().multiply(this.transformationMatrix).transformPoint(this.point)
+    }
 }
+
+export class TectonicLine {
+    start: TectonicPoint
+    end: TectonicPoint
+
+    constructor(startParentTransformations: Ref<TransformationMatrix>[], startPoint: Point, endParentTransformations: Ref<TransformationMatrix>[], endPoint: Point) {
+        this.start = new TectonicPoint(startParentTransformations, startPoint)
+        this.end = new TectonicPoint(endParentTransformations, endPoint)
+    }
+
+    toLine(): Line {
+        return {start: this.start.toPoint(), end: this.end.toPoint()}
+    }
+  }

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -4,12 +4,13 @@ import { TransformationMatrix } from "./transformationMatrix"
 import { computed, ComputedRef, Ref } from 'vue'
 import { getLineLength, getPointAlongLine } from "../functions/drawFuncs"
 
-export class TectonicPlate extends CtxArtist{
+export class TectonicPlate extends CtxArtist {
     currentLocation: Point = {x: 0, y: 0}
     desiredLocation: ComputedRef<Point>
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], desiredLocation: ComputedRef<Point> = computed(() => {return {x: 0, y: 0}})) {
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], desiredLocation: ComputedRef<Point> = computed(() => {return {x: 0, y: 0}}), anchorPoints: {[name: string]: Point} = {}) {
         super(parentTransformations, new TransformationMatrix())
         this.desiredLocation = desiredLocation
+        this.anchorPoints = anchorPoints
     }
 
     moveTowardDesiredLocation() {
@@ -27,5 +28,13 @@ export class TectonicPlate extends CtxArtist{
         }
         this.moveTo(newLocation)
         this.currentLocation = newLocation
+    }
+}
+
+export class TectonicPoint extends CtxArtist {
+    point: Point
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], point: Point = {x: 0, y: 0}) {
+        super(parentTransformations, new TransformationMatrix())
+        this.point = point
     }
 }

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -21,10 +21,10 @@ export class TectonicPlate extends CtxArtist {
         const lineToTravel: Line = {start: currentLocation, end: desiredLocation}
 
         let newLocation: Point = {x: 0, y: 0}
-        if (getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)) < 0.5) {
+        if (getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)) < 0.1) {
             newLocation = desiredLocation
         } else {
-            newLocation = getPointAlongLine(lineToTravel, 0.3)
+            newLocation = getPointAlongLine(lineToTravel, 0.1) // 0.3
         }
         this.moveTo(newLocation)
         this.currentLocation = newLocation

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -16,8 +16,6 @@ export class TectonicPlate extends CtxArtist {
     }
 
     moveTowardDesiredLocation() {
-        console.log(this.transformationMatrix.translation)
-
         const currentLocation = this.currentLocation
         const desiredLocation = this.desiredLocation.value
         const lineToTravel: Line = {start: currentLocation, end: desiredLocation}

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -5,20 +5,22 @@ import { computed, ComputedRef, Ref } from 'vue'
 import { getLineLength, getPointAlongLine } from "../functions/drawFuncs"
 
 export class TectonicPlate extends CtxArtist {
+    static allTectonicPlates: TectonicPlate[] = []
     currentLocation: Point = {x: 0, y: 0}
     desiredLocation: ComputedRef<Point>
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], desiredLocation: ComputedRef<Point> = computed(() => {return {x: 0, y: 0}}), anchorPoints: {[name: string]: Point} = {}) {
         super(parentTransformations, new TransformationMatrix())
         this.desiredLocation = desiredLocation
         this.anchorPoints = anchorPoints
+        TectonicPlate.allTectonicPlates.push(this)
     }
 
     moveTowardDesiredLocation() {
+        console.log(this.transformationMatrix.translation)
+
         const currentLocation = this.currentLocation
         const desiredLocation = this.desiredLocation.value
-        console.log("currentLocation: ", currentLocation, "desiredLocation", desiredLocation)
         const lineToTravel: Line = {start: currentLocation, end: desiredLocation}
-        console.log(getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)))
 
         let newLocation: Point = {x: 0, y: 0}
         if (getLineLength(CtxArtist.textTransformationMatrix.transformLine(lineToTravel)) < 0.5) {
@@ -55,4 +57,4 @@ export class TectonicLine {
     toLine(): Line {
         return {start: this.start.toPoint(), end: this.end.toPoint()}
     }
-  }
+}

--- a/src/classes/transformationMatrix.ts
+++ b/src/classes/transformationMatrix.ts
@@ -75,6 +75,8 @@ export class TransformationMatrix {
     set translation(newLocation: Point) {
         this.translate({x: -this.translation.x, y: -this.translation.y}, true)
         this.translate(newLocation, true)
+        // this.matrix.values[0][2] = newLocation.x
+        // this.matrix.values[1][2] = newLocation.y
     }
 
     rotate(angle: number, inPlace: boolean = false): TransformationMatrix {

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -15,15 +15,15 @@ export class VoltageSource extends CtxArtist{
     current: number // in Amps
     fixedAt: 'gnd' | 'vdd'
 
-    constructor(parentTransformationMatrix: TransformationMatrix, origin: Point, vminus: Ref<Node>, vplus: Ref<Node>, name: string, fixedAt: 'gnd' | 'vdd', mirror: boolean = false) {
-        super(parentTransformationMatrix.translate(origin).mirror(mirror, false).scale(1/30))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point, vminus: Ref<Node>, vplus: Ref<Node>, name: string, fixedAt: 'gnd' | 'vdd', mirror: boolean = false) {
+        super(parentTransformations, (new TransformationMatrix()).translate(origin).mirror(mirror, false).scale(1/30))
         this.vplus = vplus
         this.vminus = vminus
         this.fixedAt = fixedAt
         if (fixedAt == 'gnd') {
-            this.voltageDrop = new AngleSlider(this.transformationMatrix.mirror(false, false), vminus, vplus, 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible)
+            this.voltageDrop = new AngleSlider(this.transformations, vminus, vplus, 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible)
         } else {
-            this.voltageDrop = new AngleSlider(this.transformationMatrix.mirror(false, false), vplus, vminus, 0, 0, 50, toRadians(40), toRadians(80), true, -5, 0, name, Visibility.Visible, true)
+            this.voltageDrop = new AngleSlider(this.transformations, vplus, vminus, 0, 0, 50, toRadians(40), toRadians(80), true, -5, 0, name, Visibility.Visible, true)
         }
         this.schematicEffects = {}
         this.current = 0 // Amps

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -27,6 +27,11 @@ export class VoltageSource extends CtxArtist{
         }
         this.schematicEffects = {}
         this.current = 0 // Amps
+
+        this.anchorPoints = {
+            "Vplus": {x: 0, y: -60},
+            "Vminus": {x: 0, y: 60},
+        }
     }
 
     draw(ctx: CanvasRenderingContext2D) {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -46,7 +46,7 @@ const handleClickOutside = (event: MouseEvent) => {
 }
 
 type DefinedCircuits = keyof typeof circuits
-const currentCircuit = ref<DefinedCircuits>('nMos9TransistorOpAmp')
+const currentCircuit = ref<DefinedCircuits>('pMosSingle')
 const circuitsToChooseFrom = Object.keys(circuits) as DefinedCircuits[]
 
 const circuit = shallowRef(circuits[currentCircuit.value])

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -46,7 +46,7 @@ const handleClickOutside = (event: MouseEvent) => {
 }
 
 type DefinedCircuits = keyof typeof circuits
-const currentCircuit = ref<DefinedCircuits>('pMosSingle')
+const currentCircuit = ref<DefinedCircuits>('nMos9TransistorOpAmp')
 const circuitsToChooseFrom = Object.keys(circuits) as DefinedCircuits[]
 
 const circuit = shallowRef(circuits[currentCircuit.value])

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { Point } from './types'
 
+export const moveNodesInResponseToCircuitState = true
 export const drawGrid = false // normally false
 export const canvasDpi = 2
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { Point } from './types'
 
 export const moveNodesInResponseToCircuitState = true
-export const drawGrid = true // normally false
+export const drawGrid = false // normally false
 export const canvasDpi = 2
 
 export const canvasSize = {x: window.innerWidth - 100, y: window.innerHeight - 100}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { Point } from './types'
 
 export const moveNodesInResponseToCircuitState = true
-export const drawGrid = false // normally false
+export const drawGrid = true // normally false
 export const canvasDpi = 2
 
 export const canvasSize = {x: window.innerWidth - 100, y: window.innerHeight - 100}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { Point } from './types'
 
 export const moveNodesInResponseToCircuitState = true
-export const drawGrid = false // normally false
+export const drawGrid = true // false // normally false
 export const canvasDpi = 2
 
 export const canvasSize = {x: window.innerWidth - 100, y: window.innerHeight - 100}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { Point } from './types'
 
 export const moveNodesInResponseToCircuitState = true
-export const drawGrid = true // false // normally false
+export const drawGrid = false // normally false
 export const canvasDpi = 2
 
 export const canvasSize = {x: window.innerWidth - 100, y: window.innerHeight - 100}

--- a/src/functions/extraMath.ts
+++ b/src/functions/extraMath.ts
@@ -1,3 +1,6 @@
+export const foldr = <A, B>(f: (x: A, acc: B) => B, acc: B, [h, ...t]: A[]): B => h === undefined ? acc : f(h, foldr(f, acc, t)) // https://dev.to/omkarpatil/folds-in-typescript-3ml2
+export const foldl = <A, B>(f: (x: A, acc: B) => B, acc: B, [h, ...t]: A[]): B => h === undefined ? acc : foldl(f, f(h, acc), t) // https://dev.to/omkarpatil/folds-in-typescript-3ml2
+
 export const toDegrees = (theta: number): number => {
   return theta * 180 / Math.PI
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import { Ref } from 'vue'
 import { Node } from './classes/node'
-import { TectonicPoint } from './classes/tectonicPlate';
 
 export type PublicInterface<T> = Pick<T, keyof T>;
 
@@ -55,9 +54,4 @@ export type Line = {
 export type Circle = {
   center: Point,
   outerDiameter: number,
-}
-
-export type TectonicLine = {
-  start: TectonicPoint,
-  end: TectonicPoint,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,14 @@ export type Chart = {
 }
 
 export type SchematicEffect = {
+  node: Ref<Node>,
+  origin: TectonicPoint,
+  color: string,
+  gradientSize: number,
+
+}
+
+export type FlattenedSchematicEffect = {
   origin: Point,
   color: string,
   gradientSize: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,7 @@
 import { Ref } from 'vue'
-import { Matrix } from 'ts-matrix'
 import { Node } from './classes/node'
-import { Schematic } from './classes/schematic'
-import { Mosfet } from './classes/mosfet'
-import { VoltageSource } from './classes/voltageSource'
-import { AngleSlider } from './classes/angleSlider'
+
+export type PublicInterface<T> = Pick<T, keyof T>;
 
 export type Point = {
   x: number
@@ -35,72 +32,12 @@ export type Chart = {
   cornerToCornerGraph?: boolean
 }
 
-// export type AngleSlider = {
-//   transformationMatrix: Matrix,
-//   textTransformationMatrix: Matrix,
-//   dragging: boolean,
-//   preciseDragging: boolean,
-//   location: Point,
-//   radius: number,
-//   originalRadius: number,
-//   // center: Point, // obsolete
-//   // startAngle: number, // obsolete
-//   endAngle: number,
-//   // CCW: boolean, // obsolete
-//   displayText: string,
-//   displayTextLocation: RelativeDirection,
-//   minValue: number,
-//   maxValue: number,
-//   value: number, // a number between minValue and maxValue
-//   visibility: Visibility
-//   data: Point[],
-//   displayNegative: boolean,
-//   temporaryMinValue: number,
-//   temporaryMaxValue: number,
-//   previousValue: number,
-//   valueRateOfChange: number,
-// }
-
 export type SchematicEffect = {
   node: Ref<Node>,
   origin: Point,
   color: string,
   gradientSize: number,
 }
-
-// export type Mosfet = {
-//   transformationMatrix: Matrix,
-//   textTransformationMatrix: Matrix,
-//   mosfetType: 'nmos' | 'pmos',
-//   // originX: number, // obsolete
-//   // originY: number, // obsolete
-//   mirror: boolean, // obsolete
-//   dotPercentage: number,
-//   gradientSize: number,
-//   schematicEffects: {[name: string]: SchematicEffect},
-//   vgs: AngleSlider,
-//   vds: AngleSlider,
-//   Vg: Ref<Node>,
-//   Vs: Ref<Node>,
-//   Vd: Ref<Node>,
-//   Vb: Ref<Node>,
-//   current: number, // in Amps
-//   saturationLevel: number, // as a fraction of total saturation (0 to 1)
-//   forwardCurrent: number // in Amps
-// }
-
-// export type VoltageSource = {
-//   transformationMatrix: Matrix,
-//   textTransformationMatrix: Matrix,
-//   // originX: number, // obsolete
-//   // originY: number, // obsolete
-//   voltageDrop: AngleSlider,
-//   vplus: Ref<Node>,
-//   vminus: Ref<Node>,
-//   schematicEffects: {[name: string]: SchematicEffect},
-//   current: number, // in Amps
-//   fixedAt: 'gnd' | 'vdd',
-// }
 
 export type Wire = {
   node: Ref<Node>,
@@ -118,46 +55,3 @@ export type Circle = {
   center: Point,
   outerDiameter: number,
 }
-
-// export type Schematic = {
-//   vddLocations: Point[], // a list of locations to draw vdd symbols
-//   gndLocations: Point[], // a list of locations to draw gnd symbols
-//   parasiticCapacitors: ParasiticCapacitor[],
-// }
-
-// export type ParasiticCapacitor = {
-//   transformationMatrix: Matrix,
-//   textTransformationMatrix: Matrix,
-//   circuitTransformationMatrix: Matrix,
-//   node: Ref<Node>,
-//   extraNodeLines: Line[],
-//   currentPath: Line[],
-//   dotPercentage: number,
-// }
-
-// export type Node = {
-//   voltage: number, // in Volts
-//   netCurrent: number, // in Amps
-//   capacitance: number, // in Farads
-//   originalCapacitance: number // in
-//   fixed: boolean, // GND and VDD nodes are fixed, as are nodes that are being dragged
-//   historicVoltages: Queue<number>,
-//   lines: Line[],
-//   voltageDisplayLabel: string,
-//   voltageDisplayLocations: Point[],
-// }
-
-// export type Circuit = {
-//   transformationMatrix: Matrix,
-//   textTransformationMatrix: Matrix,
-//   schematic: Schematic, // how to draw the circuit
-//   // drawSchematic: () => void, // a function to draw the non-device parts of the circuit
-//   devices: {
-//     mosfets: {[name: string]: Mosfet}, // a dictionary mapping the names of the mosfets with Mosfet devices
-//     voltageSources: {[name: string]: VoltageSource}, // a dictionary mapping the names of the voltage sources with VoltageSource devices
-//   },
-//   allSliders: AngleSlider[], // a list of all the AngleSliders belonging to all of the devices, to make it easier to loop over them
-//   nodes: {[nodeId: string]: Ref<Node>}, // a dictionary mapping the names of the nodes in the circuit with their voltages (in V)
-//   // solveNodeVoltages: (circuit: Circuit) => void, // a function that returns a list of the voltages (in V) at each of the nodes of the circuit
-//   // checkKirchoffsLaws: () => void, // a function that runs a series of assertions ensuring that KCL and KVL hold within a small tolerance
-// }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { Ref } from 'vue'
 import { Node } from './classes/node'
+import { TectonicLine, TectonicPoint } from './classes/tectonicPlate';
 
 export type PublicInterface<T> = Pick<T, keyof T>;
 
@@ -33,7 +34,6 @@ export type Chart = {
 }
 
 export type SchematicEffect = {
-  node: Ref<Node>,
   origin: Point,
   color: string,
   gradientSize: number,
@@ -41,9 +41,9 @@ export type SchematicEffect = {
 
 export type Wire = {
   node: Ref<Node>,
-  lines: Line[],
-  label: string,
-  locations: Point[],
+  lines: TectonicLine[],
+  voltageDisplayLabel: string,
+  voltageDisplayLocations: TectonicPoint[],
 }
 
 export type Line = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,12 +33,18 @@ export type Chart = {
   cornerToCornerGraph?: boolean
 }
 
+export type BoundingBox = {
+  topLeft: TectonicPoint
+  topRight: TectonicPoint
+  bottomRight: TectonicPoint
+  bottomLeft: TectonicPoint
+}
+
 export type SchematicEffect = {
   node: Ref<Node>,
   origin: TectonicPoint,
   color: string,
   gradientSize: number,
-
 }
 
 export type FlattenedSchematicEffect = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { Ref } from 'vue'
 import { Node } from './classes/node'
+import { TectonicPoint } from './classes/tectonicPlate';
 
 export type PublicInterface<T> = Pick<T, keyof T>;
 
@@ -54,4 +55,9 @@ export type Line = {
 export type Circle = {
   center: Point,
   outerDiameter: number,
+}
+
+export type TectonicLine = {
+  start: TectonicPoint,
+  end: TectonicPoint,
 }


### PR DESCRIPTION
Make parts of the circuit move around based on circuit state. Change `CtxArtist.transformationMatrix` to a computed ref based on the product of a list of refs to its ancestors' transformation matrices. Thus, a change to an ancestor's transformation matrix will propagate down to all its children.

Create `TectonicPlate` objects which store an additional transformation matrix and can be used as an ancestor, such that any object with any `TectonicPlate.transformations` as a parent for its own transformation matrix will move around as the `TectonicPlate` moves around. Also create `TectonicPoint` and `TectonicLine` objects which are transformation-aware versions of the `Point` and `Line` objects and contain methods to convert them into points in the `Circuit` reference frame at draw time.