### PR TITLE
Graph bar rewrite and improvements

### DIFF
--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -310,7 +310,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
         ]
     )
 
-    circuit.circuitCopy = circuit.copy()
+    circuit.finishSetup()
     return circuit
 }
 export default useNmos5TransistorOpAmp

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -310,6 +310,7 @@ const useNmos5TransistorOpAmp = (): Circuit => {
         ]
     )
 
+    circuit.circuitCopy = circuit.copy()
     return circuit
 }
 export default useNmos5TransistorOpAmp

--- a/src/circuits/nMos5TransistorOpAmp.ts
+++ b/src/circuits/nMos5TransistorOpAmp.ts
@@ -213,10 +213,10 @@ const useNmos5TransistorOpAmp = (): Circuit => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [
-            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
             new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("SourceSupply")),
-            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
-            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
         ],
         [
             new VddSymbol(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("SourceSupply")),
@@ -237,6 +237,9 @@ const useNmos5TransistorOpAmp = (): Circuit => {
                 node: circuit.nodes[gndNodeId],
                 lines: [
                     new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("SourceSupply")),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -432,7 +432,7 @@ const useNmos9TransistorOpAmp = () => {
         ]
     )
 
-    circuit.circuitCopy = circuit.copy()
+    circuit.finishSetup()
     return circuit
 }
 export default useNmos9TransistorOpAmp

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -431,6 +431,8 @@ const useNmos9TransistorOpAmp = () => {
             },
         ]
     )
+
+    circuit.circuitCopy = circuit.copy()
     return circuit
 }
 export default useNmos9TransistorOpAmp

--- a/src/circuits/nMos9TransistorOpAmp.ts
+++ b/src/circuits/nMos9TransistorOpAmp.ts
@@ -314,9 +314,9 @@ const useNmos9TransistorOpAmp = () => {
             new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("SourceSupply")),
             new GndSymbol(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("SourceSupply")),
             new GndSymbol(...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("SourceSupply")),
-            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
-            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
-            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
         ],
         [
             new VddSymbol(...circuit.devices.mosfets["M3"].getAnchorPointWithTransformations("SourceSupply")),
@@ -334,6 +334,9 @@ const useNmos9TransistorOpAmp = () => {
                     new TectonicLine(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("SourceSupply")),
                     new TectonicLine(...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M7"].getAnchorPointWithTransformations("SourceSupply")),
                     new TectonicLine(...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("Vs"), ...circuit.devices.mosfets["M8"].getAnchorPointWithTransformations("SourceSupply")),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -159,10 +159,10 @@ const useNmosDiffPair = () => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [
-            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus")),
             new GndSymbol(...circuit.devices.mosfets["Mb"].getAnchorPointWithTransformations("SourceSupply")),
-            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus")),
-            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus")),
+            new GndSymbol(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+            new GndSymbol(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
         ],
         [
             new VddSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("DrainSupply")),
@@ -176,6 +176,9 @@ const useNmosDiffPair = () => {
                 node: circuit.nodes[gndNodeId],
                 lines: [
                     new TectonicLine(circuit.transformations, {x: 0, y: 8}, circuit.transformations, {x: 0, y: 9}),
+                    new TectonicLine(...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["Vb"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V1"].getAnchorPointWithTransformations("gnd")),
+                    new TectonicLine(...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("Vminus"), ...circuit.devices.voltageSources["V2"].getAnchorPointWithTransformations("gnd")),
                 ],
                 voltageDisplayLabel: "",
                 voltageDisplayLocations: []

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -230,7 +230,7 @@ const useNmosDiffPair = () => {
         ]
     )
 
-    circuit.circuitCopy = circuit.copy()
+    circuit.finishSetup()
     return circuit
 }
 export default useNmosDiffPair

--- a/src/circuits/nMosDiffPair.ts
+++ b/src/circuits/nMosDiffPair.ts
@@ -230,6 +230,7 @@ const useNmosDiffPair = () => {
         ]
     )
 
+    circuit.circuitCopy = circuit.copy()
     return circuit
 }
 export default useNmosDiffPair

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -108,6 +108,7 @@ const useNmosSingle = () => {
         ]
     )
 
+    circuit.circuitCopy = circuit.copy()
     return circuit
 }
 export default useNmosSingle

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -108,7 +108,7 @@ const useNmosSingle = () => {
         ]
     )
 
-    circuit.circuitCopy = circuit.copy()
+    circuit.finishSetup()
     return circuit
 }
 export default useNmosSingle

--- a/src/circuits/nMosSingle.ts
+++ b/src/circuits/nMosSingle.ts
@@ -32,18 +32,21 @@ const useNmosSingle = () => {
     //////////////////////////////
 
     const tectonicPlate: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
-        return getPointAlongPath([{start: {x: 0, y: 0}, end: {x: 0, y: -6}}],
+        return getPointAlongPath([{start: {x: 0, y: 2}, end: {x: 0, y: -4}}],
             between(gndVoltage, vddVoltage, circuit.nodes["M1_drain"].value.voltage) / (vddVoltage - gndVoltage))
     }))
-    const tectonicPlateChart: TectonicPlate = new TectonicPlate(tectonicPlate.transformations, computed(() => {
-        return (circuit.devices.mosfets["M1"].selected.value) ? {x: 6, y: 0} : {x: 0, y: 0}
+    const tectonicPlateVdd: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return {x: 0, y: -4}
+    }))
+    const tectonicPlateChart: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return (circuit.devices.mosfets["M1"].selected.value) ? {x: 7, y: 0} : {x: 0, y: 0}
     }))
 
     circuit.boundingBox = [
-        new TectonicPoint(tectonicPlate.transformations, {x: -5, y: -12}),
-        new TectonicPoint(tectonicPlateChart.transformations, {x: 5, y: -12}),
+        new TectonicPoint(tectonicPlateVdd.transformations, {x: -5, y: -12}),
+        new TectonicPoint(tectonicPlate.transformations, {x: 5, y: -12}),
         new TectonicPoint(circuit.transformations, {x: -5, y: 6}),
-        new TectonicPoint(circuit.transformations, {x: 5, y: 6}),
+        new TectonicPoint(tectonicPlateChart.transformations, {x: 5, y: 6}),
     ]
 
     //////////////////////////////
@@ -61,7 +64,7 @@ const useNmosSingle = () => {
             circuit.nodes["M1_drain"],
             circuit.nodes[gndNodeId],
             circuit.nodes[gndNodeId],
-            3, 5, false, Visibility.Visible, Visibility.Visible, 'gate'
+            3, 5, false, Visibility.Visible, Visibility.Visible, 'furtherGate'
         )
     }
 
@@ -92,7 +95,8 @@ const useNmosSingle = () => {
     circuit.schematic = new Schematic(
         circuit.transformations,
         [new GndSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs"))],
-        [new VddSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus"))],
+        // [new VddSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus"))],
+        [new VddSymbol(tectonicPlateVdd.transformations, {x: 0, y: -8})],
         [],
         Object.values(circuit.devices.mosfets),
         Object.values(circuit.nodes),
@@ -103,7 +107,15 @@ const useNmosSingle = () => {
                     new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus")),
                 ],
                 voltageDisplayLabel: "Drain",
-                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: -3})]
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: -4})]
+            },
+            {
+                node: circuit.nodes[vddNodeId],
+                lines: [
+                    new TectonicLine(tectonicPlateVdd.transformations, {x: 0, y: -8}, ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
             },
         ]
     )

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -32,18 +32,21 @@ const usePmosSingle = () => {
     //////////////////////////////
 
     const tectonicPlate: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
-        return getPointAlongPath([{start: {x: 0, y: 6}, end: {x: 0, y: 0}}],
+        return getPointAlongPath([{start: {x: 0, y: 4}, end: {x: 0, y: -2}}],
             between(gndVoltage, vddVoltage, circuit.nodes["M1_drain"].value.voltage) / (vddVoltage - gndVoltage))
     }))
+    const tectonicPlateGnd: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
+        return {x: 0, y: 4}
+    }))
     const tectonicPlateChart: TectonicPlate = new TectonicPlate(circuit.transformations, computed(() => {
-        return (circuit.devices.mosfets["M1"].selected.value) ? {x: 6, y: 0} : {x: 0, y: 0}
+        return (circuit.devices.mosfets["M1"].selected.value) ? {x: 7, y: 0} : {x: 0, y: 0}
     }))
 
     circuit.boundingBox = [
         new TectonicPoint(circuit.transformations, {x: -5, y: -6}),
         new TectonicPoint(tectonicPlateChart.transformations, {x: 5, y: -6}),
-        new TectonicPoint(tectonicPlate.transformations, {x: -5, y: 12}),
-        new TectonicPoint(tectonicPlate.transformations, {x: 5, y: 12}),
+        new TectonicPoint(tectonicPlateGnd.transformations, {x: -5, y: 12}),
+        new TectonicPoint(tectonicPlateGnd.transformations, {x: 5, y: 12}),
     ]
 
     //////////////////////////////
@@ -61,7 +64,7 @@ const usePmosSingle = () => {
             circuit.nodes["M1_drain"],
             circuit.nodes[vddNodeId],
             circuit.nodes[gndNodeId],
-            3, 5, false, Visibility.Visible, Visibility.Visible, 'gate'
+            3, 5, false, Visibility.Visible, Visibility.Visible, 'furtherGate'
         )
     }
 
@@ -90,7 +93,8 @@ const usePmosSingle = () => {
 
     circuit.schematic = new Schematic(
         circuit.transformations,
-        [new GndSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus"))],
+        // [new GndSymbol(...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus"))],
+        [new GndSymbol(tectonicPlateGnd.transformations, {x: 0, y: 8})],
         [new VddSymbol(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vs"))],
         [],
         Object.values(circuit.devices.mosfets),
@@ -102,7 +106,15 @@ const usePmosSingle = () => {
                     new TectonicLine(...circuit.devices.mosfets["M1"].getAnchorPointWithTransformations("Vd"), ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vplus")),
                 ],
                 voltageDisplayLabel: "Drain",
-                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: 3})]
+                voltageDisplayLocations: [new TectonicPoint(tectonicPlate.transformations, {x: 0.5, y: 4.5})]
+            },
+            {
+                node: circuit.nodes[gndNodeId],
+                lines: [
+                    new TectonicLine(tectonicPlateGnd.transformations, {x: 0, y: 8}, ...circuit.devices.voltageSources["Vd"].getAnchorPointWithTransformations("Vminus")),
+                ],
+                voltageDisplayLabel: "",
+                voltageDisplayLocations: []
             },
         ]
     )

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -107,7 +107,7 @@ const usePmosSingle = () => {
         ]
     )
 
-    circuit.circuitCopy = circuit.copy()
+    circuit.finishSetup()
     return circuit
 }
 export default usePmosSingle

--- a/src/circuits/pMosSingle.ts
+++ b/src/circuits/pMosSingle.ts
@@ -107,6 +107,7 @@ const usePmosSingle = () => {
         ]
     )
 
+    circuit.circuitCopy = circuit.copy()
     return circuit
 }
 export default usePmosSingle

--- a/src/classes/angleSlider.ts
+++ b/src/classes/angleSlider.ts
@@ -1,4 +1,4 @@
-import { Point, RelativeDirection, Visibility } from "../types"
+import { canvasId, Point, RelativeDirection, Visibility } from "../types"
 import { TransformationMatrix } from "./transformationMatrix"
 import { toSiPrefix } from "../functions/toSiPrefix"
 import { between, toRadians } from "../functions/extraMath"
@@ -13,8 +13,8 @@ export class AngleSlider extends CtxSlider{
     displayText: string
     displayTextLocation: RelativeDirection
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], fromNode: Ref<Node>, toNode: Ref<Node>, drivenNode: 'fromNode' | 'toNode', centerX: number, centerY: number, radius: number, startAngle: number, endAngle: number, CCW: boolean, minValue: number, maxValue: number, name: string, visibility: Visibility) {
-        super(parentTransformations, (new TransformationMatrix()).translate({x: centerX, y: centerY}).rotate(startAngle).mirror(false, CCW), fromNode, toNode, drivenNode, minValue, maxValue, visibility)
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], fromNode: Ref<Node>, toNode: Ref<Node>, drivenNode: 'fromNode' | 'toNode', centerX: number, centerY: number, radius: number, startAngle: number, endAngle: number, CCW: boolean, minValue: number, maxValue: number, name: string, visibility: Visibility, canvasId: canvasId = 'main') {
+        super(parentTransformations, (new TransformationMatrix()).translate({x: centerX, y: centerY}).rotate(startAngle).mirror(false, CCW), fromNode, toNode, drivenNode, minValue, maxValue, visibility, canvasId)
 
         this.radius = radius
         this.originalRadius = radius

--- a/src/classes/chart.ts
+++ b/src/classes/chart.ts
@@ -1,6 +1,6 @@
 import { Visibility, Point, canvasId } from "../types"
 import { TransformationMatrix } from "./transformationMatrix"
-import { ref, Ref } from 'vue'
+import { Ref } from 'vue'
 import { toSiPrefix } from "../functions/toSiPrefix"
 import { getTickLabelList } from '../functions/getTickLabelList'
 import { drawLinesFillSolid } from "../functions/drawFuncs"

--- a/src/classes/chart.ts
+++ b/src/classes/chart.ts
@@ -102,9 +102,9 @@ export class Chart extends CtxSlider{
         ]
     }
 
-    copy(canvasId: canvasId = 'main'): Chart {
+    copy(parentTransformation: Ref<TransformationMatrix>, canvasId: canvasId = 'main'): Chart {
         const newChart = new Chart(
-            [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
+            [parentTransformation],
             this.mosfetType,
             this.chartType,
             0,

--- a/src/classes/chart.ts
+++ b/src/classes/chart.ts
@@ -1,4 +1,4 @@
-import { Visibility, Point } from "../types"
+import { Visibility, Point, canvasId } from "../types"
 import { TransformationMatrix } from "./transformationMatrix"
 import { ref, Ref } from 'vue'
 import { toSiPrefix } from "../functions/toSiPrefix"
@@ -53,12 +53,12 @@ export class Chart extends CtxSlider{
     yScale: number = 0
     boundingBox: TectonicPoint[]
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', chartType: 'Vgs' | 'Vds', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, gnd: Ref<Node>, maxValue: number = 5, xAxisLabel: string = "x Var", yAxisLabel: string = "y Var", xUnit: string = "xUnit", yUnit: string = "yUnit", xScaleType: 'log' | 'linear' = 'linear', yScaleType: 'log' | 'linear' = 'log', width: number = 250, height: number = 200, visibility: Visibility = Visibility.Visible) {
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', chartType: 'Vgs' | 'Vds', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, gnd: Ref<Node>, maxValue: number = 5, xAxisLabel: string = "x Var", yAxisLabel: string = "y Var", xUnit: string = "xUnit", yUnit: string = "yUnit", xScaleType: 'log' | 'linear' = 'linear', yScaleType: 'log' | 'linear' = 'log', width: number = 250, height: number = 200, visibility: Visibility = Visibility.Visible, canvasId: canvasId = 'main') {
         const fromNode = gnd
         const toNode = chartType == 'Vgs' ? Vg : Vd
         const drivenNode: 'fromNode' | 'toNode' = 'toNode'
 
-        super(parentTransformations, (new TransformationMatrix()).translate({x: originX, y: originY}), fromNode, toNode, drivenNode, 0, maxValue, visibility)
+        super(parentTransformations, (new TransformationMatrix()).translate({x: originX, y: originY}), fromNode, toNode, drivenNode, 0, maxValue, visibility, canvasId)
         if (this.transformationMatrix.isMirrored) {
             this.transformations[this.transformations.length - 1].value.mirror(true, false, true)
         }
@@ -102,7 +102,7 @@ export class Chart extends CtxSlider{
         ]
     }
 
-    copy(): Chart {
+    copy(canvasId: canvasId = 'main'): Chart {
         const newChart = new Chart(
             [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
             this.mosfetType,
@@ -123,7 +123,8 @@ export class Chart extends CtxSlider{
             this.yScaleType,
             this.width,
             this.height,
-            this.visibility
+            this.visibility,
+            canvasId
         )
         return newChart
     }
@@ -137,8 +138,6 @@ export class Chart extends CtxSlider{
         } else {
             this.transformationMatrix.transformCanvas(ctx)
         }
-
-        console.log("chart value: ", this.value)
 
         const axisLineThickness = this.localLineThickness / 2
         const tickLineThickness = this.localLineThickness / 4

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -25,6 +25,8 @@ export class Circuit extends CtxArtist {
     selectedDevice: Mosfet | VoltageSource | null = null
     selectedDeviceBoundingBox: TectonicPoint[] = []
     selectedDeviceCharts: Chart[] = []
+    selectedSchematic: Schematic | null = null
+    selectedSchematicOrigin: TectonicPoint = new TectonicPoint([], {x: 0, y: 0})
     nodes: {[nodeId: string]: Ref<Node>} // a dictionary mapping the names of the nodes in the circuit with their voltages (in V)
     textTransformationMatrix: TransformationMatrix
     originalTextTransformationMatrix: TransformationMatrix
@@ -103,6 +105,13 @@ export class Circuit extends CtxArtist {
             CtxArtist.textTransformationMatrix.relativeScale = this.selectedDevice.transformationMatrix.relativeScale
             this.selectedDevice.draw(graphBarMosfetCtx)
 
+            if (this.selectedSchematic) {
+                console.log(this.selectedSchematicOrigin.toPoint())
+                this.selectedSchematic.transformations[0].value = this.selectedDevice.transformations[0].value as TransformationMatrix
+                this.selectedSchematic.transformations[1].value.translation = {x: -this.selectedSchematicOrigin.toPoint().x, y: -this.selectedSchematicOrigin.toPoint().y}
+                this.selectedSchematic.draw(graphBarMosfetCtx)
+            }
+
             this.selectedDeviceCharts.forEach((chart: Chart) => {
                 chart.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarChartCtx, [
                     new TectonicPoint(this.transformations, {x: -150, y: 0}),
@@ -113,7 +122,6 @@ export class Circuit extends CtxArtist {
                 CtxArtist.textTransformationMatrix.relativeScale = chart.transformationMatrix.relativeScale
                 chart.draw(graphBarChartCtx)
             })
-            // this.schematic.draw(graphBarMosfetCtx)
         }
 
         ctx.restore()
@@ -128,10 +136,15 @@ export class Circuit extends CtxArtist {
         } else {
             this.selectedDeviceCharts = []
         }
+
+        this.selectedSchematic = this.schematic.copy()
+        this.selectedSchematicOrigin = new TectonicPoint(device.transformations, {x: 0, y: 0})
     }
 
     resetSelectedDevice() {
         this.selectedDevice = null
+        this.selectedDeviceCharts = []
+        this.selectedSchematic = null
     }
 
     makeListOfSliders(): CtxSlider[] {

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -14,7 +14,6 @@ import { TectonicPlate, TectonicPoint } from "./tectonicPlate"
 import { CtxSlider } from "./ctxSlider"
 import { canvasDpi, drawGrid, moveNodesInResponseToCircuitState } from "../globalState"
 import { Chart } from "./chart"
-import { AngleSlider } from "./angleSlider"
 
 export class Circuit extends CtxArtist {
     boundingBox: TectonicPoint[]
@@ -32,6 +31,7 @@ export class Circuit extends CtxArtist {
     textTransformationMatrix: TransformationMatrix
     originalTextTransformationMatrix: TransformationMatrix
     circuitCopy: CircuitCopy | null
+    anyDevicesSelected: boolean = false
 
     constructor(origin: Point, width: number, height: number, schematic: Schematic = new Schematic(), mosfets: {[name: string]: Mosfet} = {}, voltageSources: {[name: string]: VoltageSource} = {}, nodes: {[nodeId: string]: Ref<Node>} = {}, textTransformationMatrix = new TransformationMatrix()) {
         // const scale = Math.min(canvasSize.value.width / width, canvasSize.value.height / height) // TODO: Can probably delete, since this gets set elsewhere
@@ -114,7 +114,6 @@ export class Circuit extends CtxArtist {
 
         this.schematic.draw(ctx)
         Object.values(this.devices.mosfets).forEach((mosfet: Mosfet) => {
-            console.log(this)
             mosfet.draw(ctx)
         })
         Object.values(this.devices.voltageSources).forEach((voltageSource: VoltageSource) => {
@@ -136,6 +135,7 @@ export class Circuit extends CtxArtist {
             new TectonicPoint(device.transformations, {x: 0, y: -100}),
             new TectonicPoint(device.transformations, {x: 0, y: 100}),
         ]
+        this.anyDevicesSelected = true
 
         if (!this.circuitCopy) {
             return
@@ -157,6 +157,7 @@ export class Circuit extends CtxArtist {
         this.selectedDevice = null
         this.selectedDeviceCharts = []
         this.selectedSchematic = null
+        this.anyDevicesSelected = false
 
         if (!this.circuitCopy) {
             return

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -221,8 +221,8 @@ class CircuitCopy extends Circuit {
     override setCtxArtistScale() {
         // this.transformations[1].value = this.transformations[0].value.inverse()//.translate({x: 5000, y: 5000})
         // // // // this.transformations[0].value = this.devices.mosfets["M1"].transformations[1].value.inverse().multiply(this.transformations[0].value)
-        this.transformations[0].value = this.transformations[0].value.multiply(this.devices.mosfets["M1"].transformations[1].value.inverse())
         // this.devices.mosfets["M1"].transformations[2].value = this.devices.mosfets["M1"].transformations[1].value.inverse()
+        this.transformations[0].value = this.transformations[0].value.multiply(this.devices.mosfets["M1"].transformations[1].value.inverse())
         console.log("----------------------")
         console.log(this.devices.mosfets["M1"].transformations[1].value.matrix.values)
         console.log(this.transformations.map(tf => tf.value.matrix.values))

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -124,7 +124,7 @@ export class Circuit extends CtxArtist {
     }
 
     drawSelectedDeviceCharts(ctx: CanvasRenderingContext2D) {
-        this.selectedDeviceChartsTransformationMatrix.value = this.calculateTransformationMatrixBasedOnBoundingBox(ctx,
+        const chartTransformationMatrix = this.calculateTransformationMatrixBasedOnBoundingBox(ctx,
             [
                 new TectonicPoint(this.transformations, {x: -120, y: 0}),
                 new TectonicPoint(this.transformations, {x: 120, y: 0}),
@@ -132,6 +132,8 @@ export class Circuit extends CtxArtist {
                 new TectonicPoint(this.transformations, {x: 0, y: 120}),
             ]
         )
+        this.selectedDeviceChartsTransformationMatrix.value = chartTransformationMatrix
+        CtxArtist.textTransformationMatrix.relativeScale = chartTransformationMatrix.relativeScale
         this.selectedDeviceCharts.forEach((chart: Chart) => {
             chart.draw(ctx)
         })
@@ -142,10 +144,10 @@ export class Circuit extends CtxArtist {
             return
         }
         this.circuitCopy.boundingBox = [
-            new TectonicPoint(device.transformations, {x: -100, y: 0}),
-            new TectonicPoint(device.transformations, {x: 100, y: 0}),
-            new TectonicPoint(device.transformations, {x: 0, y: -100}),
-            new TectonicPoint(device.transformations, {x: 0, y: 100}),
+            new TectonicPoint(device.transformations, {x: -120, y: 0}),
+            new TectonicPoint(device.transformations, {x: 120, y: 0}),
+            new TectonicPoint(device.transformations, {x: 0, y: -120}),
+            new TectonicPoint(device.transformations, {x: 0, y: 120}),
         ]
         this.anyDevicesSelected = true
 

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -106,7 +106,6 @@ export class Circuit extends CtxArtist {
             this.selectedDevice.draw(graphBarMosfetCtx)
 
             if (this.selectedSchematic) {
-                console.log(this.selectedSchematicOrigin.toPoint())
                 this.selectedSchematic.transformations[0].value = this.selectedDevice.transformations[0].value as TransformationMatrix
                 this.selectedSchematic.transformations[1].value.translation = {x: -this.selectedSchematicOrigin.toPoint().x, y: -this.selectedSchematicOrigin.toPoint().y}
                 this.selectedSchematic.draw(graphBarMosfetCtx)

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -222,7 +222,7 @@ class CircuitCopy extends Circuit {
         // this.transformations[1].value = this.transformations[0].value.inverse()//.translate({x: 5000, y: 5000})
         // // // // this.transformations[0].value = this.devices.mosfets["M1"].transformations[1].value.inverse().multiply(this.transformations[0].value)
         // this.devices.mosfets["M1"].transformations[2].value = this.devices.mosfets["M1"].transformations[1].value.inverse()
-        this.transformations[0].value = this.transformations[0].value.multiply(this.devices.mosfets["M1"].transformations[1].value.inverse())
+        // this.transformations[0].value = this.transformations[0].value.multiply(this.devices.mosfets["M1"].transformations[1].value.inverse())
         console.log("----------------------")
         console.log(this.devices.mosfets["M1"].transformations[1].value.matrix.values)
         console.log(this.transformations.map(tf => tf.value.matrix.values))

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -122,11 +122,11 @@ export class Circuit extends CtxArtist {
             return
         }
 
-        this.selectedDevice = device.copy()
+        this.selectedDevice = device.copy('mosfet')
         this.selectedDevice.isDuplicate = true
 
         if (this.selectedDevice instanceof Mosfet) {
-            this.selectedDeviceCharts = [this.selectedDevice.vgsChart.copy(), this.selectedDevice.vdsChart.copy()]
+            this.selectedDeviceCharts = [this.selectedDevice.vgsChart.copy('chart'), this.selectedDevice.vdsChart.copy('chart')]
         } else {
             this.selectedDeviceCharts = []
         }

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -133,7 +133,6 @@ export class Circuit extends CtxArtist {
             ]
         )
         this.selectedDeviceCharts.forEach((chart: Chart) => {
-            console.log(chart)
             chart.draw(ctx)
         })
     }

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -89,6 +89,10 @@ export class Circuit extends CtxArtist {
         if (drawGrid.value) {
             this.drawGrid(ctx)
         }
+        if (graphBarMosfetCtx.canvas.width == 0 || graphBarMosfetCtx.canvas.height == 0 || graphBarChartCtx.canvas.width == 0 || graphBarChartCtx.canvas.height == 0) {
+            return
+        }
+
         if (this.selectedDevice) {
             this.selectedDevice.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarMosfetCtx, [
                     new TectonicPoint(this.transformations, {x: -130, y: 0}),
@@ -115,13 +119,7 @@ export class Circuit extends CtxArtist {
         ctx.restore()
     }
 
-    setSelectedDevice(device: Mosfet | VoltageSource, graphBarMosfetCtx: CanvasRenderingContext2D | null, graphBarChartCtx: CanvasRenderingContext2D | null) {
-        if (!graphBarMosfetCtx || !graphBarChartCtx) {
-            console.log("aborting setting selected device")
-            this.selectedDevice = null
-            return
-        }
-
+    setSelectedDevice(device: Mosfet | VoltageSource) {
         this.selectedDevice = device.copy('mosfet')
         this.selectedDevice.isDuplicate = true
 

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -95,33 +95,33 @@ export class Circuit extends CtxArtist {
             return
         }
 
-        if (this.selectedDevice) {
-            this.selectedDevice.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarMosfetCtx, [
-                    new TectonicPoint(this.transformations, {x: -130, y: 0}),
-                    new TectonicPoint(this.transformations, {x: 130, y: 0}),
-                    new TectonicPoint(this.transformations, {x: 0, y: -100}),
-                    new TectonicPoint(this.transformations, {x: 0, y: 100}),
-            ]).scale(schematicScale)
-            CtxArtist.textTransformationMatrix.relativeScale = this.selectedDevice.transformationMatrix.relativeScale
-            this.selectedDevice.draw(graphBarMosfetCtx)
+        // if (this.selectedDevice) {
+        //     this.selectedDevice.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarMosfetCtx, [
+        //             new TectonicPoint(this.transformations, {x: -130, y: 0}),
+        //             new TectonicPoint(this.transformations, {x: 130, y: 0}),
+        //             new TectonicPoint(this.transformations, {x: 0, y: -100}),
+        //             new TectonicPoint(this.transformations, {x: 0, y: 100}),
+        //     ]).scale(schematicScale)
+        //     CtxArtist.textTransformationMatrix.relativeScale = this.selectedDevice.transformationMatrix.relativeScale
+        //     this.selectedDevice.draw(graphBarMosfetCtx)
 
-            if (this.selectedSchematic) {
-                this.selectedSchematic.transformations[0].value = this.selectedDevice.transformations[0].value as TransformationMatrix
-                this.selectedSchematic.transformations[1].value.translation = {x: -this.selectedSchematicOrigin.toPoint().x, y: -this.selectedSchematicOrigin.toPoint().y}
-                this.selectedSchematic.draw(graphBarMosfetCtx)
-            }
+        //     if (this.selectedSchematic) {
+        //         this.selectedSchematic.transformations[0].value = this.selectedDevice.transformations[0].value as TransformationMatrix
+        //         this.selectedSchematic.transformations[1].value.translation = {x: -this.selectedSchematicOrigin.toPoint().x, y: -this.selectedSchematicOrigin.toPoint().y}
+        //         this.selectedSchematic.draw(graphBarMosfetCtx)
+        //     }
 
-            this.selectedDeviceCharts.forEach((chart: Chart) => {
-                chart.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarChartCtx, [
-                    new TectonicPoint(this.transformations, {x: -150, y: 0}),
-                    new TectonicPoint(this.transformations, {x: 150, y: 0}),
-                    new TectonicPoint(this.transformations, {x: 0, y: -150}),
-                    new TectonicPoint(this.transformations, {x: 0, y: 150}),
-                ])
-                CtxArtist.textTransformationMatrix.relativeScale = chart.transformationMatrix.relativeScale
-                chart.draw(graphBarChartCtx)
-            })
-        }
+        //     this.selectedDeviceCharts.forEach((chart: Chart) => {
+        //         chart.transformations[0].value = this.calculateTransformationMatrixBasedOnBoundingBox(graphBarChartCtx, [
+        //             new TectonicPoint(this.transformations, {x: -150, y: 0}),
+        //             new TectonicPoint(this.transformations, {x: 150, y: 0}),
+        //             new TectonicPoint(this.transformations, {x: 0, y: -150}),
+        //             new TectonicPoint(this.transformations, {x: 0, y: 150}),
+        //         ])
+        //         CtxArtist.textTransformationMatrix.relativeScale = chart.transformationMatrix.relativeScale
+        //         chart.draw(graphBarChartCtx)
+        //     })
+        // }
 
         ctx.restore()
     }

--- a/src/classes/circuit.ts
+++ b/src/classes/circuit.ts
@@ -114,6 +114,7 @@ export class Circuit extends CtxArtist {
 
         this.schematic.draw(ctx)
         Object.values(this.devices.mosfets).forEach((mosfet: Mosfet) => {
+            console.log(this)
             mosfet.draw(ctx)
         })
         Object.values(this.devices.voltageSources).forEach((voltageSource: VoltageSource) => {
@@ -234,8 +235,11 @@ export class Circuit extends CtxArtist {
         const width = Math.abs(right - left)
         const origin = {x: left + width / 2, y: top + height / 2}
 
-        const scale = Math.min((ctx.canvas.width / canvasDpi.value) / width, (ctx.canvas.height / canvasDpi.value) / height)
-        const extraShift = {x: ((ctx.canvas.width / canvasDpi.value) / scale - width) / 2, y: ((ctx.canvas.height / canvasDpi.value) / scale - height) / 2}
+        const canvasWidth = Math.max(ctx.canvas.width, 1)
+        const canvasHeight = Math.max(ctx.canvas.height, 1)
+
+        const scale = Math.min((canvasWidth / canvasDpi.value) / width, (canvasHeight / canvasDpi.value) / height)
+        const extraShift = {x: ((canvasWidth / canvasDpi.value) / scale - width) / 2, y: ((canvasHeight / canvasDpi.value) / scale - height) / 2}
 
         const transformationMatrix = (new TransformationMatrix()).scale(canvasDpi.value * scale).translate(extraShift).translate({x: -origin.x + width / 2, y: -origin.y + height / 2})
         return transformationMatrix
@@ -259,7 +263,5 @@ class CircuitCopy extends Circuit {
     override copy(): CircuitCopy | null {
         return null
     }
-    override setCtxArtistScale() {
-        console.log(this)
-    }
+    override setCtxArtistScale() {}
 }

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -31,6 +31,10 @@ export class CtxArtist {
         return this.transformations[this.transformations.length - 1].value
     }
 
+    // protected draw?():void // virtual method, to be implemented by child classes
+
+    // protected copy?():void // virtual method, to be implemented by child classes
+
     getAnchorPoint(name: string): Point {
         if (this.anchorPoints[name] == undefined) {
             console.log("Cannot find anchor point", name, "on CtxArtist")

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -9,6 +9,7 @@ export class CtxArtist {
     anchorPoints: {[name: string]: Point} = {}
     _transformationMatrix: ComputedRef<TransformationMatrix>
     canvasId: canvasId
+    key: string = ""
 
     static textTransformationMatrix: TransformationMatrix = new TransformationMatrix()
     static circuitTransformationMatrix: TransformationMatrix = new TransformationMatrix()

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -33,10 +33,6 @@ export class CtxArtist {
         return this.transformations[this.transformations.length - 1].value
     }
 
-    // protected draw?():void // virtual method, to be implemented by child classes
-
-    // protected copy?():void // virtual method, to be implemented by child classes
-
     getAnchorPoint(name: string): Point {
         if (this.anchorPoints[name] == undefined) {
             console.log("Cannot find anchor point", name, "on CtxArtist")

--- a/src/classes/ctxArtist.ts
+++ b/src/classes/ctxArtist.ts
@@ -1,4 +1,4 @@
-import { Point } from "../types"
+import { canvasId, Point } from "../types"
 import { TransformationMatrix } from "./transformationMatrix"
 import { GLOBAL_LINE_THICKNESS } from "../constants"
 import { computed, ComputedRef, ref, Ref } from "vue"
@@ -8,12 +8,13 @@ export class CtxArtist {
     transformations: Ref<TransformationMatrix>[] = []
     anchorPoints: {[name: string]: Point} = {}
     _transformationMatrix: ComputedRef<TransformationMatrix>
+    canvasId: canvasId
 
     static textTransformationMatrix: TransformationMatrix = new TransformationMatrix()
     static circuitTransformationMatrix: TransformationMatrix = new TransformationMatrix()
     static allCtxArtists: CtxArtist[] = []
 
-    constructor (parentTransformations: Ref<TransformationMatrix>[] = [], localTransformationMatrix: TransformationMatrix = new TransformationMatrix()) {
+    constructor (parentTransformations: Ref<TransformationMatrix>[] = [], localTransformationMatrix: TransformationMatrix = new TransformationMatrix(), canvasId: canvasId = 'main') {
         // this.transformations: [ ref(topLevelTM), ref(circuitTM), ref(mosfetTM), ref(angleSliderTM), ref(thisTM) ]
         // if you change the last element of this.transformations[this.transformations.length - 1], it will propagate down to all children
         parentTransformations.forEach(transformation => {this.transformations.push(transformation)}) // make a shallow copy of the array
@@ -21,6 +22,7 @@ export class CtxArtist {
         this._transformationMatrix = computed(() => { return foldl<Ref<TransformationMatrix>, TransformationMatrix>((x, result) => result.multiply(x.value), new TransformationMatrix(), this.transformations) })
 
         CtxArtist.allCtxArtists.push(this)
+        this.canvasId = canvasId
     }
 
     get transformationMatrix(): TransformationMatrix {

--- a/src/classes/ctxSlider.ts
+++ b/src/classes/ctxSlider.ts
@@ -1,4 +1,4 @@
-import { Point, Visibility } from "../types"
+import { canvasId, Point, Visibility } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { between } from "../functions/extraMath"
@@ -16,6 +16,7 @@ export class CtxSlider extends CtxArtist{
     maxValue: number
     value: number // a number between minValue and maxValue
     drivenNode: 'fromNode' | 'toNode'
+    canvasId: canvasId
 
     preciseDragging: boolean = false
     temporaryMinValue: number
@@ -24,7 +25,7 @@ export class CtxSlider extends CtxArtist{
     valueRateOfChange: number = 0
 
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], localTransformationMatrix: TransformationMatrix = new TransformationMatrix(), fromNode: Ref<Node>, toNode: Ref<Node>, drivenNode: 'fromNode' | 'toNode', minValue: number, maxValue: number, visibility: Visibility = Visibility.Visible) {
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], localTransformationMatrix: TransformationMatrix = new TransformationMatrix(), fromNode: Ref<Node>, toNode: Ref<Node>, drivenNode: 'fromNode' | 'toNode', minValue: number, maxValue: number, visibility: Visibility = Visibility.Visible, canvasId: canvasId = 'main') {
         super(parentTransformations, localTransformationMatrix)
 
         this.visibility = visibility
@@ -37,6 +38,7 @@ export class CtxSlider extends CtxArtist{
         this.temporaryMaxValue = maxValue
         this.previousValue = minValue
         this.drivenNode = drivenNode
+        this.canvasId = canvasId
     }
 
     draw(ctx: CanvasRenderingContext2D) {

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -12,7 +12,7 @@ import { Node } from "./node"
 import { CurrentDots } from "./currentDots"
 import { TectonicPoint } from "./tectonicPlate"
 import { Chart } from "./chart"
-import { GLOBAL_LINE_THICKNESS, vddVoltage } from "../constants"
+import { vddVoltage } from "../constants"
 
 export class Mosfet extends CtxArtist{
     mosfetType: 'nmos' | 'pmos'
@@ -27,12 +27,14 @@ export class Mosfet extends CtxArtist{
     Vs: Ref<Node>
     Vd: Ref<Node>
     Vb: Ref<Node>
+    gndNode: Ref<Node>
     mouseDownInsideSelectionArea = false
     selected: Ref<boolean> = ref(true)
     selectedFocus: Ref<boolean> = ref(false)
     chartVisibility: Visibility = Visibility.Hidden
     vgsChart: Chart
     vdsChart: Chart
+    boundingBox: TectonicPoint[]
     static chartWidth = 200
     static chartHeight = 120
     static chartLocations = {
@@ -74,6 +76,7 @@ export class Mosfet extends CtxArtist{
         this.Vs = Vs
         this.Vd = Vd
         this.Vb = Vb
+        this.gndNode = gnd
 
         this.anchorPoints = {
             "Vg": {x: 60, y: 0},
@@ -104,6 +107,34 @@ export class Mosfet extends CtxArtist{
             this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility)
             this.currentDots = new CurrentDots([{start: {x: -15, y: 60}, end: {x: -15, y: -60}}])
         }
+
+        this.boundingBox = [
+            new TectonicPoint(this.transformations, {x: -100, y: 0}),
+            new TectonicPoint(this.transformations, {x: 100, y: 0}),
+            new TectonicPoint(this.transformations, {x: 0, y: -100}),
+            new TectonicPoint(this.transformations, {x: 0, y: 100}),
+        ]
+    }
+
+    copy(): Mosfet {
+        const newMosfet = new Mosfet(
+            [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
+            this.mosfetType,
+            0,
+            0,
+            this.Vg,
+            this.Vs,
+            this.Vd,
+            this.Vb,
+            this.gndNode,
+            undefined,
+            undefined,
+            (this.mosfetType == 'nmos') == (this.transformationMatrix.isMirrored),
+            undefined,
+            undefined,
+            "deviceOrigin"
+        )
+        return newMosfet
     }
 
     draw(ctx: CanvasRenderingContext2D) {

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -116,9 +116,9 @@ export class Mosfet extends CtxArtist{
         ]
     }
 
-    copy(canvasId: canvasId = 'main'): Mosfet {
+    copy(parentTransformation: Ref<TransformationMatrix>, canvasId: canvasId = 'main'): Mosfet {
         const newMosfet = new Mosfet(
-            [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
+            [parentTransformation].concat(this.transformations),
             this.mosfetType,
             0,
             0,

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -12,7 +12,7 @@ import { Node } from "./node"
 import { CurrentDots } from "./currentDots"
 import { TectonicPoint } from "./tectonicPlate"
 import { Chart } from "./chart"
-import { vddVoltage } from "../constants"
+import { GLOBAL_LINE_THICKNESS, vddVoltage } from "../constants"
 
 export class Mosfet extends CtxArtist{
     mosfetType: 'nmos' | 'pmos'
@@ -41,7 +41,8 @@ export class Mosfet extends CtxArtist{
         "gate": {x: Mosfet.chartWidth / 2 + 120, y: 0},
         "voltageSource": {x: Mosfet.chartWidth / 2 + 240, y: 0},
         "lowerVoltageSource": {x: Mosfet.chartWidth / 2 + 240, y: 100},
-        "mirrorDriver": {x: Mosfet.chartWidth / 2 + 110, y: -this.chartHeight - 20}
+        "mirrorDriver": {x: Mosfet.chartWidth / 2 + 110, y: -this.chartHeight - 20},
+        "deviceOrigin": {x: 0, y: 0},
     }
 
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, gnd: Ref<Node>, maxVgs: number = 3, maxVds: number = 5, mirror: boolean = false, vgsVisibility: Visibility = Visibility.Visible, vdsVisibility: Visibility = Visibility.Visible, chartLocation: keyof typeof Mosfet.chartLocations = "gate") {
@@ -156,6 +157,7 @@ export class Mosfet extends CtxArtist{
         const forwardCurrentScaled = this.getForwardCurrentScaled()
         const gateColor = this.getGateColorFromForwardCurrent()
 
+        // const lineThickness = this.isDuplicate ? GLOBAL_LINE_THICKNESS : this.localLineThickness
         drawLinesFillSolid(ctx, bodyLines, this.localLineThickness, 'black')
         drawLinesFillSolid(ctx, gateLines, this.localLineThickness, gateColor)
         drawCirclesFillSolid(ctx, gateCircles, this.localLineThickness, gateColor)
@@ -183,7 +185,7 @@ export class Mosfet extends CtxArtist{
         ctx.font = "14px sans-serif";
         this.fillTextGlobalReferenceFrame(ctx, nextLineLocation, currentSuffix, true, true)
 
-        if (this.selected.value) {
+        if (this.selected.value && !this.isDuplicate) {
             this.vgsChart.draw(ctx)
             this.vdsChart.draw(ctx)
         }

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -159,16 +159,16 @@ export class Mosfet extends CtxArtist{
             ctx.arc(0, 0, 200, 0, 2 * Math.PI)
             ctx.fill()
         }
-        else if (this.selected.value && !this.isDuplicate) {
-            const backgroundGradient = ctx.createRadialGradient(0, 0, 0, 0, 0, 100)
-            backgroundGradient.addColorStop(0, 'rgba(255, 0, 0, 0)')
-            backgroundGradient.addColorStop(0.5, 'rgba(255, 0, 0, 0)')
-            backgroundGradient.addColorStop(0.8, 'rgba(255, 0, 0, 0.2)')
-            backgroundGradient.addColorStop(1, 'rgba(255, 0, 0, 0)')
-            ctx.fillStyle = backgroundGradient
-            ctx.arc(0, 0, 200, 0, 2 * Math.PI)
-            ctx.fill()
-        }
+        // else if (this.selected.value && !this.isDuplicate) {
+        //     const backgroundGradient = ctx.createRadialGradient(0, 0, 0, 0, 0, 100)
+        //     backgroundGradient.addColorStop(0, 'rgba(255, 0, 0, 0)')
+        //     backgroundGradient.addColorStop(0.5, 'rgba(255, 0, 0, 0)')
+        //     backgroundGradient.addColorStop(0.8, 'rgba(255, 0, 0, 0.2)')
+        //     backgroundGradient.addColorStop(1, 'rgba(255, 0, 0, 0)')
+        //     ctx.fillStyle = backgroundGradient
+        //     ctx.arc(0, 0, 200, 0, 2 * Math.PI)
+        //     ctx.fill()
+        // }
 
         const bodyLines: Line[] = [
             {start: {x: 0, y: 20}, end: {x: 0, y: 59}},

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -135,8 +135,8 @@ export class Mosfet extends CtxArtist{
             undefined,
             undefined,
             (this.mosfetType == 'nmos') == (this.transformationMatrix.isMirrored),
-            undefined,
-            undefined,
+            this.vgs.visibility,
+            this.vds.visibility,
             "deviceOrigin",
             canvasId
         )

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -118,7 +118,7 @@ export class Mosfet extends CtxArtist{
 
     copy(parentTransformation: Ref<TransformationMatrix>, canvasId: canvasId = 'main'): Mosfet {
         const newMosfet = new Mosfet(
-            [parentTransformation].concat(this.transformations),
+            [parentTransformation].concat(this.transformations.slice(1)),
             this.mosfetType,
             0,
             0,

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -29,7 +29,7 @@ export class Mosfet extends CtxArtist{
     Vb: Ref<Node>
     gndNode: Ref<Node>
     mouseDownInsideSelectionArea = false
-    selected: Ref<boolean> = ref(true)
+    selected: Ref<boolean> = ref(false)
     selectedFocus: Ref<boolean> = ref(false)
     chartVisibility: Visibility = Visibility.Hidden
     vgsChart: Chart

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -41,6 +41,7 @@ export class Mosfet extends CtxArtist{
         "base": {x: -Mosfet.chartWidth / 2 - 100, y: 0},
         "lowerBase": {x: -Mosfet.chartWidth / 2 - 100, y: 100},
         "gate": {x: Mosfet.chartWidth / 2 + 120, y: 0},
+        "furtherGate": {x: Mosfet.chartWidth / 2 + 150, y: 0},
         "voltageSource": {x: Mosfet.chartWidth / 2 + 240, y: 0},
         "lowerVoltageSource": {x: Mosfet.chartWidth / 2 + 240, y: 100},
         "mirrorDriver": {x: Mosfet.chartWidth / 2 + 110, y: -this.chartHeight - 20},

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -92,19 +92,24 @@ export class Mosfet extends CtxArtist{
             "Vg_drive_Vsource": {x: 120, y: 90},
         }
 
+        let chartCanvasId: canvasId = 'main'
+        if (canvasId == 'mosfet') {
+            chartCanvasId = 'chart'
+        }
+
         // maybe can be condensed down to one case
         if (this.mosfetType == 'nmos') {
             this.vgs = new AngleSlider(this.transformations, Vs, Vg, 'toNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility, canvasId)
             this.vds = new AngleSlider(this.transformations, Vs, Vd, 'toNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility, canvasId)
-            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, canvasId)
-            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, canvasId)
+            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, chartCanvasId)
+            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, chartCanvasId)
             this.currentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
         }
         else {
             this.vgs = new AngleSlider(this.transformations, Vg, Vs, 'fromNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vsg', vgsVisibility, canvasId)
             this.vds = new AngleSlider(this.transformations, Vd, Vs, 'fromNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vsd', vdsVisibility, canvasId)
-            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, canvasId)
-            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, canvasId)
+            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, chartCanvasId)
+            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, chartCanvasId)
             this.currentDots = new CurrentDots([{start: {x: -15, y: 60}, end: {x: -15, y: -60}}])
         }
 

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -1,4 +1,4 @@
-import { Visibility, SchematicEffect, Line, Point, Circle } from "../types"
+import { Visibility, SchematicEffect, Line, Point, Circle, canvasId } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { AngleSlider } from "./angleSlider"
@@ -47,8 +47,8 @@ export class Mosfet extends CtxArtist{
         "deviceOrigin": {x: 0, y: 0},
     }
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, gnd: Ref<Node>, maxVgs: number = 3, maxVds: number = 5, mirror: boolean = false, vgsVisibility: Visibility = Visibility.Visible, vdsVisibility: Visibility = Visibility.Visible, chartLocation: keyof typeof Mosfet.chartLocations = "gate") {
-        super(parentTransformations, (new TransformationMatrix()).translate({x: originX, y: originY}).scale(1/30).mirror(mirror, mosfetType == 'pmos'))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], mosfetType: 'nmos' | 'pmos', originX: number, originY: number, Vg: Ref<Node>, Vs: Ref<Node>, Vd: Ref<Node>, Vb: Ref<Node>, gnd: Ref<Node>, maxVgs: number = 3, maxVds: number = 5, mirror: boolean = false, vgsVisibility: Visibility = Visibility.Visible, vdsVisibility: Visibility = Visibility.Visible, chartLocation: keyof typeof Mosfet.chartLocations = "gate", canvasId: canvasId = 'main') {
+        super(parentTransformations, (new TransformationMatrix()).translate({x: originX, y: originY}).scale(1/30).mirror(mirror, mosfetType == 'pmos'), canvasId)
 
         this.mosfetType = mosfetType
         this.schematicEffects = {
@@ -94,17 +94,17 @@ export class Mosfet extends CtxArtist{
 
         // maybe can be condensed down to one case
         if (this.mosfetType == 'nmos') {
-            this.vgs = new AngleSlider(this.transformations, Vs, Vg, 'toNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility)
-            this.vds = new AngleSlider(this.transformations, Vs, Vd, 'toNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility)
-            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility)
-            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility)
+            this.vgs = new AngleSlider(this.transformations, Vs, Vg, 'toNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vgs', vgsVisibility, canvasId)
+            this.vds = new AngleSlider(this.transformations, Vs, Vd, 'toNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vds', vdsVisibility, canvasId)
+            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, canvasId)
+            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, canvasId)
             this.currentDots = new CurrentDots([{start: {x: -15, y: -60}, end: {x: -15, y: 60}}])
         }
         else {
-            this.vgs = new AngleSlider(this.transformations, Vg, Vs, 'fromNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vsg', vgsVisibility)
-            this.vds = new AngleSlider(this.transformations, Vd, Vs, 'fromNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vsd', vdsVisibility)
-            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility)
-            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility)
+            this.vgs = new AngleSlider(this.transformations, Vg, Vs, 'fromNode', 10, 10, 60, toRadians(75), toRadians(70), true, 0, maxVgs, 'Vsg', vgsVisibility, canvasId)
+            this.vds = new AngleSlider(this.transformations, Vd, Vs, 'fromNode', 30, 0, 75, toRadians(140), toRadians(80), false, 0, maxVds, 'Vsd', vdsVisibility, canvasId)
+            this.vgsChart = new Chart(this.transformations, mosfetType, 'Vgs', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vg", "Current", "V", "A", 'linear', 'log', 200, 115, vgsVisibility, canvasId)
+            this.vdsChart = new Chart(this.transformations, mosfetType, 'Vds', Mosfet.chartLocations[chartLocation].x, Mosfet.chartLocations[chartLocation].y, Vg, Vs, Vd, Vb, gnd, 5, "Vd", "Saturation Level", "V", "%", 'linear', 'linear', 200, 115, vdsVisibility, canvasId)
             this.currentDots = new CurrentDots([{start: {x: -15, y: 60}, end: {x: -15, y: -60}}])
         }
 
@@ -116,7 +116,7 @@ export class Mosfet extends CtxArtist{
         ]
     }
 
-    copy(): Mosfet {
+    copy(canvasId: canvasId = 'main'): Mosfet {
         const newMosfet = new Mosfet(
             [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
             this.mosfetType,
@@ -132,7 +132,8 @@ export class Mosfet extends CtxArtist{
             (this.mosfetType == 'nmos') == (this.transformationMatrix.isMirrored),
             undefined,
             undefined,
-            "deviceOrigin"
+            "deviceOrigin",
+            canvasId
         )
         return newMosfet
     }

--- a/src/classes/mosfet.ts
+++ b/src/classes/mosfet.ts
@@ -135,6 +135,8 @@ export class Mosfet extends CtxArtist{
             "deviceOrigin",
             canvasId
         )
+        newMosfet.isDuplicate = true
+        newMosfet.transformations[newMosfet.transformations.length - 1].value = new TransformationMatrix()
         return newMosfet
     }
 

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -22,6 +22,14 @@ export class GndSymbol extends CtxArtist{
         ctx.lineTo(0, 0)
         ctx.stroke()
     }
+
+    copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): GndSymbol {
+        const newGndSymbol = new GndSymbol(
+            parentTransformations,
+            this.transformations[this.transformations.length - 1].value.translation
+        )
+        return newGndSymbol
+    }
 }
 
 export class VddSymbol extends CtxArtist{
@@ -39,5 +47,13 @@ export class VddSymbol extends CtxArtist{
         ctx.moveTo(symbolSize / 2, 0)
         ctx.lineTo(-symbolSize / 2, 0)
         ctx.stroke()
+    }
+
+    copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): VddSymbol {
+        const newVddSymbol = new VddSymbol(
+            parentTransformations,
+            this.transformations[this.transformations.length - 1].value.translation
+        )
+        return newVddSymbol
     }
 }

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -1,7 +1,7 @@
 import { Point } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
-import { Ref } from "vue"
+import { ref, Ref } from "vue"
 
 export class GndSymbol extends CtxArtist{
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point) {
@@ -24,8 +24,14 @@ export class GndSymbol extends CtxArtist{
     }
 
     copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): GndSymbol {
+        console.log("logging")
+        console.log(this.transformations.map(m => m.value.matrix.values))
+        let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
+        for (let i = this.transformations.length - 1; i >= 3; i--) {
+            newTransformations = newTransformations.concat(this.transformations[i])
+        }
         const newGndSymbol = new GndSymbol(
-            parentTransformations,
+            newTransformations,
             this.transformations[this.transformations.length - 1].value.translation
         )
         return newGndSymbol
@@ -50,8 +56,12 @@ export class VddSymbol extends CtxArtist{
     }
 
     copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): VddSymbol {
+        let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
+        for (let i = this.transformations.length - 1; i >= 3; i--) {
+            newTransformations = newTransformations.concat(this.transformations[i])
+        }
         const newVddSymbol = new VddSymbol(
-            parentTransformations,
+            newTransformations,
             this.transformations[this.transformations.length - 1].value.translation
         )
         return newVddSymbol

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -1,7 +1,7 @@
 import { Point } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
-import { ref, Ref } from "vue"
+import { Ref } from "vue"
 
 export class GndSymbol extends CtxArtist{
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point) {
@@ -24,8 +24,6 @@ export class GndSymbol extends CtxArtist{
     }
 
     copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): GndSymbol {
-        console.log("logging")
-        console.log(this.transformations.map(m => m.value.matrix.values))
         let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
         for (let i = 2; i <= this.transformations.length - 1; i++) {
             newTransformations = newTransformations.concat(this.transformations[i])
@@ -33,7 +31,6 @@ export class GndSymbol extends CtxArtist{
         const newGndSymbol = new GndSymbol(
             newTransformations,
             {x: 0, y: 0}
-            // this.transformations[this.transformations.length - 1].value.translation
         )
         return newGndSymbol
     }
@@ -64,7 +61,6 @@ export class VddSymbol extends CtxArtist{
         const newVddSymbol = new VddSymbol(
             newTransformations,
             {x: 0, y: 0}
-            // this.transformations[this.transformations.length - 1].value.translation
         )
         return newVddSymbol
     }

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -23,13 +23,9 @@ export class GndSymbol extends CtxArtist{
         ctx.stroke()
     }
 
-    copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): GndSymbol {
-        let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
-        for (let i = 2; i <= this.transformations.length - 1; i++) {
-            newTransformations = newTransformations.concat(this.transformations[i])
-        }
+    copy(parentTransformation: Ref<TransformationMatrix>): GndSymbol {
         const newGndSymbol = new GndSymbol(
-            newTransformations,
+            [parentTransformation].concat(this.transformations),
             {x: 0, y: 0}
         )
         return newGndSymbol
@@ -53,13 +49,9 @@ export class VddSymbol extends CtxArtist{
         ctx.stroke()
     }
 
-    copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): VddSymbol {
-        let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
-        for (let i = 2; i <= this.transformations.length - 1; i++) {
-            newTransformations = newTransformations.concat(this.transformations[i])
-        }
+    copy(parentTransformation: Ref<TransformationMatrix>): VddSymbol {
         const newVddSymbol = new VddSymbol(
-            newTransformations,
+            [parentTransformation].concat(this.transformations),
             {x: 0, y: 0}
         )
         return newVddSymbol

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -25,7 +25,7 @@ export class GndSymbol extends CtxArtist{
 
     copy(parentTransformation: Ref<TransformationMatrix>): GndSymbol {
         const newGndSymbol = new GndSymbol(
-            [parentTransformation].concat(this.transformations),
+            [parentTransformation].concat(this.transformations.slice(1)),
             {x: 0, y: 0}
         )
         return newGndSymbol
@@ -51,7 +51,7 @@ export class VddSymbol extends CtxArtist{
 
     copy(parentTransformation: Ref<TransformationMatrix>): VddSymbol {
         const newVddSymbol = new VddSymbol(
-            [parentTransformation].concat(this.transformations),
+            [parentTransformation].concat(this.transformations.slice(1)),
             {x: 0, y: 0}
         )
         return newVddSymbol

--- a/src/classes/powerSymbols.ts
+++ b/src/classes/powerSymbols.ts
@@ -27,12 +27,13 @@ export class GndSymbol extends CtxArtist{
         console.log("logging")
         console.log(this.transformations.map(m => m.value.matrix.values))
         let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
-        for (let i = this.transformations.length - 1; i >= 3; i--) {
+        for (let i = 2; i <= this.transformations.length - 1; i++) {
             newTransformations = newTransformations.concat(this.transformations[i])
         }
         const newGndSymbol = new GndSymbol(
             newTransformations,
-            this.transformations[this.transformations.length - 1].value.translation
+            {x: 0, y: 0}
+            // this.transformations[this.transformations.length - 1].value.translation
         )
         return newGndSymbol
     }
@@ -57,12 +58,13 @@ export class VddSymbol extends CtxArtist{
 
     copy(parentTransformations: Ref<TransformationMatrix>[] | undefined): VddSymbol {
         let newTransformations: Ref<TransformationMatrix>[] = parentTransformations ? parentTransformations : []
-        for (let i = this.transformations.length - 1; i >= 3; i--) {
+        for (let i = 2; i <= this.transformations.length - 1; i++) {
             newTransformations = newTransformations.concat(this.transformations[i])
         }
         const newVddSymbol = new VddSymbol(
             newTransformations,
-            this.transformations[this.transformations.length - 1].value.translation
+            {x: 0, y: 0}
+            // this.transformations[this.transformations.length - 1].value.translation
         )
         return newVddSymbol
     }

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -30,7 +30,7 @@ export class Schematic extends CtxArtist{
 
     copy(parentTransformation: Ref<TransformationMatrix>): Schematic {
         const newSchematic = new Schematic(
-            [parentTransformation].concat(this.transformations),
+            [parentTransformation].concat(this.transformations.slice(1)),
             this.gndSymbols.map(symbol => symbol.copy(parentTransformation)),
             this.vddSymbols.map(symbol => symbol.copy(parentTransformation)),
             [], // ignore the parasitic capacitors

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -32,19 +32,17 @@ export class Schematic extends CtxArtist{
         const transformations = [ref(new TransformationMatrix()) as Ref<TransformationMatrix>, ref(new TransformationMatrix()) as Ref<TransformationMatrix>]
         const newSchematic = new Schematic(
             transformations,
-            [],
-            [],
-            // this.gndSymbols.map(symbol => symbol.copy(transformations)),
-            // this.vddSymbols.map(symbol => symbol.copy(transformations)),
+            // this.gndSymbols,
+            // this.vddSymbols,
+            this.gndSymbols.map(symbol => symbol.copy(transformations)),
+            this.vddSymbols.map(symbol => symbol.copy(transformations)),
             [], // ignore the parasitic capacitors
             this.mosfets,
             this.nodes,
             this.wires
         )
-        newSchematic.gndSymbols = this.gndSymbols.map(symbol => symbol.copy(newSchematic.transformations)),
-        newSchematic.vddSymbols = this.vddSymbols.map(symbol => symbol.copy(newSchematic.transformations)),
 
-        newSchematic.wires.forEach((wire: Wire) => {wire.voltageDisplayLocations = []})
+        // newSchematic.wires.forEach((wire: Wire) => {wire.voltageDisplayLocations = []})
         return newSchematic
     }
 

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -39,7 +39,6 @@ export class Schematic extends CtxArtist{
             // ignore the labels on wires
             this.wires.map((wire: Wire) => {return {node: wire.node, lines: wire.lines, voltageDisplayLabel: "", voltageDisplayLocations: []}})
         )
-
         // newSchematic.wires.forEach((wire: Wire) => {wire.voltageDisplayLocations = []})
         return newSchematic
     }

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -39,7 +39,11 @@ export class Schematic extends CtxArtist{
             [], // ignore the parasitic capacitors
             this.mosfets,
             this.nodes,
-            this.wires
+            // node: Ref<Node>,
+            // lines: TectonicLine[],
+            // voltageDisplayLabel: string,
+            // voltageDisplayLocations: TectonicPoint[],
+            this.wires.map((wire: Wire) => {return {node: wire.node, lines: wire.lines, voltageDisplayLabel: "", voltageDisplayLocations: []}})
         )
 
         // newSchematic.wires.forEach((wire: Wire) => {wire.voltageDisplayLocations = []})

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -2,7 +2,7 @@ import { FlattenedSchematicEffect, Point, SchematicEffect, Wire } from "../types
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { ParasiticCapacitor } from "./parasiticCapacitor"
-import { ref, Ref } from "vue"
+import { Ref } from "vue"
 import { drawLinesFillSolid, drawLinesFillWithGradient, makeStandardGradient } from "../functions/drawFuncs"
 import { Mosfet } from "./mosfet"
 import { Node } from "./node"
@@ -28,21 +28,15 @@ export class Schematic extends CtxArtist{
         this.wires = wires
     }
 
-    copy(): Schematic {
-        const transformations = [ref(new TransformationMatrix()) as Ref<TransformationMatrix>, ref(new TransformationMatrix()) as Ref<TransformationMatrix>]
+    copy(parentTransformation: Ref<TransformationMatrix>): Schematic {
         const newSchematic = new Schematic(
-            transformations,
-            // this.gndSymbols,
-            // this.vddSymbols,
-            this.gndSymbols.map(symbol => symbol.copy(transformations)),
-            this.vddSymbols.map(symbol => symbol.copy(transformations)),
+            [parentTransformation].concat(this.transformations),
+            this.gndSymbols.map(symbol => symbol.copy(parentTransformation)),
+            this.vddSymbols.map(symbol => symbol.copy(parentTransformation)),
             [], // ignore the parasitic capacitors
             this.mosfets,
             this.nodes,
-            // node: Ref<Node>,
-            // lines: TectonicLine[],
-            // voltageDisplayLabel: string,
-            // voltageDisplayLocations: TectonicPoint[],
+            // ignore the labels on wires
             this.wires.map((wire: Wire) => {return {node: wire.node, lines: wire.lines, voltageDisplayLabel: "", voltageDisplayLocations: []}})
         )
 

--- a/src/classes/schematic.ts
+++ b/src/classes/schematic.ts
@@ -2,7 +2,7 @@ import { FlattenedSchematicEffect, Point, SchematicEffect, Wire } from "../types
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { ParasiticCapacitor } from "./parasiticCapacitor"
-import { Ref } from "vue"
+import { ref, Ref } from "vue"
 import { drawLinesFillSolid, drawLinesFillWithGradient, makeStandardGradient } from "../functions/drawFuncs"
 import { Mosfet } from "./mosfet"
 import { Node } from "./node"
@@ -26,6 +26,26 @@ export class Schematic extends CtxArtist{
         this.mosfets = mosfets
         this.nodes = nodes
         this.wires = wires
+    }
+
+    copy(): Schematic {
+        const transformations = [ref(new TransformationMatrix()) as Ref<TransformationMatrix>, ref(new TransformationMatrix()) as Ref<TransformationMatrix>]
+        const newSchematic = new Schematic(
+            transformations,
+            [],
+            [],
+            // this.gndSymbols.map(symbol => symbol.copy(transformations)),
+            // this.vddSymbols.map(symbol => symbol.copy(transformations)),
+            [], // ignore the parasitic capacitors
+            this.mosfets,
+            this.nodes,
+            this.wires
+        )
+        newSchematic.gndSymbols = this.gndSymbols.map(symbol => symbol.copy(newSchematic.transformations)),
+        newSchematic.vddSymbols = this.vddSymbols.map(symbol => symbol.copy(newSchematic.transformations)),
+
+        newSchematic.wires.forEach((wire: Wire) => {wire.voltageDisplayLocations = []})
+        return newSchematic
     }
 
     draw(ctx: CanvasRenderingContext2D) {

--- a/src/classes/tectonicPlate.ts
+++ b/src/classes/tectonicPlate.ts
@@ -42,7 +42,8 @@ export class TectonicPoint extends CtxArtist {
     }
 
     toPoint(): Point {
-        return CtxArtist.circuitTransformationMatrix.inverse().multiply(this.transformationMatrix).transformPoint(this.point)
+        // return CtxArtist.circuitTransformationMatrix.inverse().multiply(this.transformationMatrix).transformPoint(this.point)
+        return this.transformations[0].value.inverse().multiply(this.transformationMatrix).transformPoint(this.point)
     }
 }
 

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -46,7 +46,7 @@ export class VoltageSource extends CtxArtist{
 
     copy(parentTransformation: Ref<TransformationMatrix>, canvasId: canvasId = 'main'): VoltageSource {
         const newVoltageSource = new VoltageSource(
-            [parentTransformation].concat(this.transformations),
+            [parentTransformation].concat(this.transformations.slice(1)),
             {x: 0, y: 0},
             this.vminus,
             this.vplus,

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -44,9 +44,9 @@ export class VoltageSource extends CtxArtist{
         ]
     }
 
-    copy(canvasId: canvasId = 'main'): VoltageSource {
+    copy(parentTransformation: Ref<TransformationMatrix>, canvasId: canvasId = 'main'): VoltageSource {
         const newVoltageSource = new VoltageSource(
-            [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
+            [parentTransformation].concat(this.transformations),
             {x: 0, y: 0},
             this.vminus,
             this.vplus,

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -55,6 +55,7 @@ export class VoltageSource extends CtxArtist{
             (this.fixedAt == 'gnd') == (this.transformationMatrix.isMirrored), // has not been checked; may be wrong logic
             canvasId
         )
+        newVoltageSource.transformations[newVoltageSource.transformations.length - 1].value = new TransformationMatrix()
         return newVoltageSource
     }
 

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -1,4 +1,4 @@
-import { Circle, Line, Point, SchematicEffect, Visibility } from "../types"
+import { canvasId, Circle, Line, Point, SchematicEffect, Visibility } from "../types"
 import { CtxArtist } from "./ctxArtist"
 import { TransformationMatrix } from "./transformationMatrix"
 import { toRadians } from "../functions/extraMath"
@@ -18,15 +18,15 @@ export class VoltageSource extends CtxArtist{
     isDuplicate: boolean = false
     boundingBox: TectonicPoint[]
 
-    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point, vminus: Ref<Node>, vplus: Ref<Node>, name: string, fixedAt: 'gnd' | 'vdd', mirror: boolean = false) {
-        super(parentTransformations, (new TransformationMatrix()).translate(origin).mirror(mirror, false).scale(1/30))
+    constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point, vminus: Ref<Node>, vplus: Ref<Node>, name: string, fixedAt: 'gnd' | 'vdd', mirror: boolean = false, canvasId: canvasId = 'main') {
+        super(parentTransformations, (new TransformationMatrix()).translate(origin).mirror(mirror, false).scale(1/30), canvasId)
         this.vplus = vplus
         this.vminus = vminus
         this.fixedAt = fixedAt
         if (fixedAt == 'gnd') {
-            this.voltageDrop = new AngleSlider(this.transformations, vminus, vplus, 'toNode', 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible)
+            this.voltageDrop = new AngleSlider(this.transformations, vminus, vplus, 'toNode', 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible, canvasId)
         } else {
-            this.voltageDrop = new AngleSlider(this.transformations.concat([ref((new TransformationMatrix().mirror(false, true))) as Ref<TransformationMatrix>]), vminus, vplus, 'fromNode', 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible)
+            this.voltageDrop = new AngleSlider(this.transformations.concat([ref((new TransformationMatrix().mirror(false, true))) as Ref<TransformationMatrix>]), vminus, vplus, 'fromNode', 0, 0, 50, toRadians(40), toRadians(80), true, 0, 5, name, Visibility.Visible, canvasId)
         }
         this.schematicEffects = {}
         this.current = 0 // Amps
@@ -44,7 +44,7 @@ export class VoltageSource extends CtxArtist{
         ]
     }
 
-    copy(): VoltageSource {
+    copy(canvasId: canvasId = 'main'): VoltageSource {
         const newVoltageSource = new VoltageSource(
             [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
             {x: 0, y: 0},
@@ -52,7 +52,8 @@ export class VoltageSource extends CtxArtist{
             this.vplus,
             this.voltageDrop.displayText,
             this.fixedAt,
-            (this.fixedAt == 'gnd') == (this.transformationMatrix.isMirrored) // has not been checked; may be wrong logic
+            (this.fixedAt == 'gnd') == (this.transformationMatrix.isMirrored), // has not been checked; may be wrong logic
+            canvasId
         )
         return newVoltageSource
     }

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -32,8 +32,10 @@ export class VoltageSource extends CtxArtist{
         this.current = 0 // Amps
 
         this.anchorPoints = {
-            "Vplus": {x: 0, y: -60},
-            "Vminus": {x: 0, y: 60},
+            "Vplus": {x: 0, y: -30},
+            "Vminus": {x: 0, y: 30},
+            "vdd": {x: 0, y: -60},
+            "gnd": {x: 0, y: 60},
         }
 
         this.boundingBox = [
@@ -73,8 +75,8 @@ export class VoltageSource extends CtxArtist{
         ctx.lineWidth = this.localLineThickness
 
         const majorLines: Line[] = [
-            {start: {x: 0, y: radius}, end: {x: 0, y: 60}},
-            {start: {x: 0, y: -radius}, end: {x: 0, y: -60}},
+            // {start: {x: 0, y: radius}, end: {x: 0, y: 60}},
+            // {start: {x: 0, y: -radius}, end: {x: 0, y: -60}},
         ]
         const minorLines: Line[] = [
             {start: {x: symbolSize / 2, y: -symbolHeight}, end: {x: -symbolSize / 2, y: -symbolHeight}},

--- a/src/classes/voltageSource.ts
+++ b/src/classes/voltageSource.ts
@@ -6,6 +6,7 @@ import { ref, Ref } from 'vue'
 import { AngleSlider } from "./angleSlider"
 import { drawCirclesFillSolid, drawLinesFillSolid } from "../functions/drawFuncs"
 import { Node } from "./node"
+import { TectonicPoint } from "./tectonicPlate"
 
 export class VoltageSource extends CtxArtist{
     voltageDrop: AngleSlider
@@ -15,6 +16,7 @@ export class VoltageSource extends CtxArtist{
     current: number // in Amps
     fixedAt: 'gnd' | 'vdd'
     isDuplicate: boolean = false
+    boundingBox: TectonicPoint[]
 
     constructor(parentTransformations: Ref<TransformationMatrix>[] = [], origin: Point, vminus: Ref<Node>, vplus: Ref<Node>, name: string, fixedAt: 'gnd' | 'vdd', mirror: boolean = false) {
         super(parentTransformations, (new TransformationMatrix()).translate(origin).mirror(mirror, false).scale(1/30))
@@ -33,6 +35,26 @@ export class VoltageSource extends CtxArtist{
             "Vplus": {x: 0, y: -60},
             "Vminus": {x: 0, y: 60},
         }
+
+        this.boundingBox = [
+            new TectonicPoint(this.transformations, {x: -100, y: 0}),
+            new TectonicPoint(this.transformations, {x: 100, y: 0}),
+            new TectonicPoint(this.transformations, {x: 0, y: -100}),
+            new TectonicPoint(this.transformations, {x: 0, y: 100}),
+        ]
+    }
+
+    copy(): VoltageSource {
+        const newVoltageSource = new VoltageSource(
+            [ref(new TransformationMatrix()) as Ref<TransformationMatrix>],
+            {x: 0, y: 0},
+            this.vminus,
+            this.vplus,
+            this.voltageDrop.displayText,
+            this.fixedAt,
+            (this.fixedAt == 'gnd') == (this.transformationMatrix.isMirrored) // has not been checked; may be wrong logic
+        )
+        return newVoltageSource
     }
 
     draw(ctx: CanvasRenderingContext2D, transformationMatrix: TransformationMatrix | undefined = undefined) {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -49,20 +49,21 @@
         class="main"
       ></canvas>
 
-      <div :style="{
+      <div
+      :style="{
         display: 'flex',
         flexDirection: xs ? 'row' : 'column',
       }">
         <canvas
           ref="graphBarChartCanvas"
           @mousedown="checkDrag"
-          :style="`background-color: yellow; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; visibility: ${showGraphBar ? 'visible' : 'hidden'}`"
+          :style="`background-color: yellow; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="chart"
         ></canvas>
         <canvas
           ref="graphBarMosfetCanvas"
           @mousedown="checkDrag"
-          :style="`background-color: green; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; visibility: ${showGraphBar ? 'visible' : 'hidden'}`"
+          :style="`background-color: green; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="mosfet"
         ></canvas>
       </div>
@@ -258,7 +259,7 @@ const mouseUp = (event: MouseEvent) => {
           mosfet.selected.value = !mosfet.selected.value
         }
         mosfet.selectedFocus.value = true
-        circuit.value.setSelectedDevice(mosfet, graphBarMosfetCtx.value, graphBarChartCtx.value)
+        circuit.value.setSelectedDevice(mosfet)
       } else {
         mosfet.selectedFocus.value = false // unselect everything when you click somewhere else
       }

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -83,7 +83,6 @@ import { moveNodesInResponseToCircuitState, drawGrid, canvasDpi, getCanvasSize, 
 import useBreakpoints from '../composables/useBreakpoints'
 import { VoltageSource } from '../classes/voltageSource'
 import { Mosfet } from '../classes/mosfet'
-import { Chart } from '../classes/chart'
 import { CtxArtist } from '../classes/ctxArtist'
 import { schematicScale } from '../constants'
 
@@ -296,7 +295,7 @@ const draw = () => {
 
   updateSlidersBasedOnNodeVoltages()
   circuit.value.draw(ctx.value as CanvasRenderingContext2D)
-  if (circuit.value.anyDevicesSelected) {
+  if (circuit.value.anyDevicesSelected && showSideBar) {
     CtxArtist.textTransformationMatrix.relativeScale = circuit.value.circuitCopy!.transformationMatrix.relativeScale / schematicScale
     circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
     // CtxArtist.textTransformationMatrix.relativeScale = circuit.value.circuitCopy!.transformationMatrix.relativeScale

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -84,6 +84,8 @@ import useBreakpoints from '../composables/useBreakpoints'
 import { VoltageSource } from '../classes/voltageSource'
 import { Mosfet } from '../classes/mosfet'
 import { Chart } from '../classes/chart'
+import { CtxArtist } from '../classes/ctxArtist'
+import { schematicScale } from '../constants'
 
 const { screenHeight, screenWidth, xs } = useBreakpoints()
 
@@ -295,8 +297,11 @@ const draw = () => {
   updateSlidersBasedOnNodeVoltages()
   circuit.value.draw(ctx.value as CanvasRenderingContext2D)
   if (circuit.value.anyDevicesSelected) {
+    CtxArtist.textTransformationMatrix.relativeScale = circuit.value.circuitCopy!.transformationMatrix.relativeScale / schematicScale
     circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
+    // CtxArtist.textTransformationMatrix.relativeScale = circuit.value.circuitCopy!.transformationMatrix.relativeScale
     circuit.value.drawSelectedDeviceCharts(graphBarChartCtx.value as CanvasRenderingContext2D)
+    // CtxArtist.textTransformationMatrix.relativeScale = circuit.value.transformationMatrix.relativeScale
   }
 }
 

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -83,6 +83,7 @@ import { moveNodesInResponseToCircuitState, drawGrid, canvasDpi, getCanvasSize, 
 import useBreakpoints from '../composables/useBreakpoints'
 import { VoltageSource } from '../classes/voltageSource'
 import { Mosfet } from '../classes/mosfet'
+import { Chart } from '../classes/chart'
 
 const { screenHeight, screenWidth, xs } = useBreakpoints()
 
@@ -295,6 +296,7 @@ const draw = () => {
   circuit.value.draw(ctx.value as CanvasRenderingContext2D)
   if (circuit.value.anyDevicesSelected) {
     circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
+    circuit.value.drawSelectedDeviceCharts(graphBarChartCtx.value as CanvasRenderingContext2D)
   }
 }
 

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -233,7 +233,7 @@ const mouseUp = (event: MouseEvent) => {
           mosfet.selected.value = !mosfet.selected.value
         }
         mosfet.selectedFocus.value = true
-        circuit.value.setSelectedDevice(mosfet)
+        circuit.value.setSelectedDevice(mosfet, graphBarMosfetCanvas.value?.width, graphBarMosfetCanvas.value?.height)
       } else {
         mosfet.selectedFocus.value = false // unselect everything when you click somewhere else
       }

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -119,26 +119,6 @@ const computedCanvasLayout = computed(() => {
     height: (screenHeight.value - padding) / 2
   }
 
-  // const graphBarChartCanvas = xs.value ?
-  // {
-  //   width: showGraphBar.value ? (screenWidth.value - padding) / 2 : 0,
-  //   height: showGraphBar.value ? bottomGraphHeight : 0
-  // } :
-  // {
-  //   width: showGraphBar.value ? sideGraphWidth : 0,
-  //   height: showGraphBar.value ? (screenHeight.value - padding) / 2 : 0
-  // }
-
-  // const graphBarMosfetCanvas = xs.value ?
-  // {
-  //   width: showGraphBar.value ? (screenWidth.value - padding) / 2 : 0,
-  //   height: showGraphBar.value ? bottomGraphHeight : 0
-  // } :
-  // {
-  //   width: showGraphBar.value ? sideGraphWidth : 0,
-  //   height: showGraphBar.value ? (screenHeight.value - padding) / 2 : 0
-  // }
-
   return {
     mainCanvas,
     graphBarChartCanvas,
@@ -294,7 +274,8 @@ const draw = () => {
   if (!setUpCtx(graphBarChartCanvas, graphBarChartCtx, graphBarChartCanvasSize)) return
 
   updateSlidersBasedOnNodeVoltages()
-  circuit.value.draw(ctx.value as CanvasRenderingContext2D, graphBarMosfetCtx.value as CanvasRenderingContext2D, graphBarChartCtx.value as CanvasRenderingContext2D)
+  circuit.value.draw(ctx.value as CanvasRenderingContext2D)
+  // circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
 }
 
 const animate = (timestamp: number) => {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -57,13 +57,13 @@
         <canvas
           ref="graphBarChartCanvas"
           @mousedown="checkDrag"
-          :style="`border-color: blue; border-width: 2px; background-color: white; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
+          :style="`border-color: blue; border-width: ${computedCanvasLayout.borderWidth}px; background-color: white; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="chart"
         ></canvas>
         <canvas
           ref="graphBarMosfetCanvas"
           @mousedown="checkDrag"
-          :style="`border-color: blue; border-width: 2px; background-color: white; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
+          :style="`border-color: blue; border-width: ${computedCanvasLayout.borderWidth}px; background-color: white; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="mosfet"
         ></canvas>
       </div>
@@ -88,6 +88,7 @@ const computedCanvasLayout = computed(() => {
   const padding = 30
   const bottomGraphHeight = screenHeight.value / 4
   const sideGraphWidth = screenWidth.value / 4
+  const borderWidth = 2
 
   const mainCanvas = xs.value ?
   {
@@ -101,28 +102,29 @@ const computedCanvasLayout = computed(() => {
 
   const graphBarChartCanvas = xs.value ?
   {
-    width: (screenWidth.value - padding) / 2,
+    width: (screenWidth.value - padding) / 2 - borderWidth,
     height: bottomGraphHeight
   } :
   {
     width: sideGraphWidth,
-    height: (screenHeight.value - padding) / 2
+    height: (screenHeight.value - padding) / 2 - borderWidth
   }
 
   const graphBarMosfetCanvas = xs.value ?
   {
-    width: (screenWidth.value - padding) / 2,
+    width: (screenWidth.value - padding) / 2 - borderWidth,
     height: bottomGraphHeight
   } :
   {
     width: sideGraphWidth,
-    height: (screenHeight.value - padding) / 2
+    height: (screenHeight.value - padding) / 2 - borderWidth
   }
 
   return {
     mainCanvas,
     graphBarChartCanvas,
-    graphBarMosfetCanvas
+    graphBarMosfetCanvas,
+    borderWidth
   }
 })
 

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -45,7 +45,7 @@
       <canvas
         ref="canvas"
         @mousedown="checkDrag"
-        :style="`width: ${computedCanvasLayout.mainCanvas.width}px; height: ${computedCanvasLayout.mainCanvas.height}px;`"
+        :style="`border-color: blue; border-width: 2px; background-color: white; width: ${computedCanvasLayout.mainCanvas.width}px; height: ${computedCanvasLayout.mainCanvas.height}px;`"
         class="main"
       ></canvas>
 
@@ -57,13 +57,13 @@
         <canvas
           ref="graphBarChartCanvas"
           @mousedown="checkDrag"
-          :style="`background-color: yellow; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
+          :style="`border-color: blue; border-width: 2px; background-color: white; width: ${computedCanvasLayout.graphBarChartCanvas.width}px; height: ${computedCanvasLayout.graphBarChartCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="chart"
         ></canvas>
         <canvas
           ref="graphBarMosfetCanvas"
           @mousedown="checkDrag"
-          :style="`background-color: green; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
+          :style="`border-color: blue; border-width: 2px; background-color: white; width: ${computedCanvasLayout.graphBarMosfetCanvas.width}px; height: ${computedCanvasLayout.graphBarMosfetCanvas.height}px; display: ${showGraphBar ? 'block' : 'none'}`"
           class="mosfet"
         ></canvas>
       </div>
@@ -88,8 +88,6 @@ const computedCanvasLayout = computed(() => {
   const padding = 30
   const bottomGraphHeight = screenHeight.value / 4
   const sideGraphWidth = screenWidth.value / 4
-
-  console.log(showGraphBar.value)
 
   const mainCanvas = xs.value ?
   {
@@ -209,8 +207,6 @@ const anySlidersDragging = (): boolean => {
 }
 
 const checkDrag = (event: MouseEvent) => {
-  console.log(event.target)
-  console.log((event.target as HTMLElement).className)
   const { mouseX, mouseY } = getMousePos(event)
   circuit.value.allSliders.forEach(slider => {
     if (slider.canvasId == (event.target as HTMLElement).className) {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -137,7 +137,7 @@ let previousTimestamp = 0
 
 const sideBar = ref<HTMLElement | null>(null)
 const showSideBar = ref(false)
-const showGraphBar = ref(false)
+const showGraphBar = ref(true)
 
 const handleClickOutside = (event: MouseEvent) => {
   if (sideBar.value && !sideBar.value.contains(event.target as Node)) showSideBar.value = false
@@ -275,7 +275,7 @@ const draw = () => {
 
   updateSlidersBasedOnNodeVoltages()
   circuit.value.draw(ctx.value as CanvasRenderingContext2D)
-  // circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
+  circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
 }
 
 const animate = (timestamp: number) => {

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -233,7 +233,7 @@ const mouseUp = (event: MouseEvent) => {
           mosfet.selected.value = !mosfet.selected.value
         }
         mosfet.selectedFocus.value = true
-        circuit.value.setSelectedDevice(mosfet, graphBarMosfetCanvas.value?.width, graphBarMosfetCanvas.value?.height)
+        circuit.value.setSelectedDevice(mosfet, graphBarMosfetCtx.value, graphBarChartCtx.value)
       } else {
         mosfet.selectedFocus.value = false // unselect everything when you click somewhere else
       }

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -319,6 +319,9 @@ const animate = (timestamp: number) => {
   Object.values(circuit.value.devices.mosfets).forEach(mosfet => {
     mosfet.currentDots.updateDotPositionBasedOnTimestamp(mosfet.current, timeDifference)
   })
+  Object.values(circuit.value.circuitCopy!.devices.mosfets).forEach(mosfet => {
+    mosfet.currentDots.updateDotPositionBasedOnTimestamp(mosfet.current, timeDifference)
+  })
   Object.values(circuit.value.schematic.parasiticCapacitors).forEach(capacitor => {
     capacitor.currentDots.updateDotPositionBasedOnTimestamp(capacitor.node.value.netCurrent, timeDifference)
   })

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -81,6 +81,8 @@ import { CtxSlider } from '../classes/ctxSlider'
 import Switch from './Switch.vue'
 import { moveNodesInResponseToCircuitState, drawGrid, canvasDpi, getCanvasSize, canvasSize, graphBarMosfetCanvasSize, graphBarChartCanvasSize } from '../globalState'
 import useBreakpoints from '../composables/useBreakpoints'
+import { VoltageSource } from '../classes/voltageSource'
+import { Mosfet } from '../classes/mosfet'
 
 const { screenHeight, screenWidth, xs } = useBreakpoints()
 
@@ -197,9 +199,14 @@ const checkDrag = (event: MouseEvent) => {
   })
 
   if (!anySlidersDragging()) {
-    Object.values(circuit.value.devices.mosfets).forEach(mosfet => {
+    Object.values(circuit.value.devices.mosfets).forEach((mosfet: Mosfet) => {
       if (mosfet.canvasId == (event.target as HTMLElement).className) {
         mosfet.mouseDownInsideSelectionArea = mosfet.checkSelectionArea({x: mouseX, y: mouseY})
+      }
+    })
+    Object.values(circuit.value.devices.voltageSources).forEach((voltageSource: VoltageSource) => {
+      if (voltageSource.canvasId == (event.target as HTMLElement).className) {
+        voltageSource.mouseDownInsideSelectionArea = voltageSource.checkSelectionArea({x: mouseX, y: mouseY})
       }
     })
   }
@@ -242,6 +249,15 @@ const mouseUp = (event: MouseEvent) => {
         mosfet.selectedFocus.value = false // unselect everything when you click somewhere else
       }
       mosfet.mouseDownInsideSelectionArea = false
+    })
+    Object.values(circuit.value.devices.voltageSources).forEach(voltageSource => {
+      if (voltageSource.mouseDownInsideSelectionArea && voltageSource.checkSelectionArea({x: mouseX, y: mouseY})) {
+        voltageSource.selectedFocus.value = true
+        circuit.value.setSelectedDevice(voltageSource)
+      } else {
+        voltageSource.selectedFocus.value = false // unselect everything when you click somewhere else
+      }
+      voltageSource.mouseDownInsideSelectionArea = false
     })
   }
 

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -277,7 +277,9 @@ const draw = () => {
 
   updateSlidersBasedOnNodeVoltages()
   circuit.value.draw(ctx.value as CanvasRenderingContext2D)
-  circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
+  if (circuit.value.anyDevicesSelected) {
+    circuit.value.circuitCopy?.draw(graphBarMosfetCtx.value as CanvasRenderingContext2D)
+  }
 }
 
 const animate = (timestamp: number) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export enum RelativeDirection {
   Down,
 }
 
+export type canvasId = 'main' | 'mosfet' | 'chart'
+
 export type BoundingBox = {
   topLeft: TectonicPoint
   topRight: TectonicPoint


### PR DESCRIPTION
Change the way the graph bar mosfet view is rendered. Instead of copying element by element, now we copy the entire circuit and update its transformation matrix to be centered on the device in question. The charts on the graph bar chart canvas are still rendered separately.
Also includes some usability and aesthetic improvements, such as sensible defaults, circuit tweaks, and replacing the voltage source leads with wires so as not to cut off the schematic effect gradients.